### PR TITLE
Visualization: Add frame_id to UTM Path Poses

### DIFF
--- a/opennav_coverage/src/visualizer.cpp
+++ b/opennav_coverage/src/visualizer.cpp
@@ -44,6 +44,7 @@ void Visualizer::visualize(
     auto utm_path = std::make_unique<nav_msgs::msg::Path>(nav_path);
     utm_path->header.frame_id = GLOBAL_FRAME;
     for (unsigned int i = 0; i != utm_path->poses.size(); i++) {
+      utm_path->poses[i].header.frame_id = GLOBAL_FRAME;
       utm_path->poses[i].pose.position.x += ref_pt.getX();
       utm_path->poses[i].pose.position.y += ref_pt.getY();
     }


### PR DESCRIPTION
This fixes an issue with visualization of the UTM path in Foxglove Studio due to a mismatch in the frame_id of the path and that of the constituent poses.