### PR TITLE
make Blackboard variable ID prive to the navigator

### DIFF
--- a/opennav_coverage_navigator/src/coverage_navigator.cpp
+++ b/opennav_coverage_navigator/src/coverage_navigator.cpp
@@ -30,13 +30,13 @@ CoverageNavigator::configure(
   auto node = parent_node.lock();
 
   path_blackboard_id_ = node->declare_or_get_parameter(
-    "path_blackboard_id", std::string("path"));
+    getName() + ".path_blackboard_id", std::string("path"));
   field_blackboard_id_ = node->declare_or_get_parameter(
-    "field_file_blackboard_id", std::string("field_filepath"));
+    getName() + ".field_file_blackboard_id", std::string("field_filepath"));
   polygon_blackboard_id_ = node->declare_or_get_parameter(
-    "field_polygon_blackboard_id", std::string("field_polygon"));
+    getName() + ".field_polygon_blackboard_id", std::string("field_polygon"));
   polygon_frame_blackboard_id_ = node->declare_or_get_parameter(
-    "polygon_frame_blackboard_id", std::string("polygon_frame_id"));
+    getName() + ".polygon_frame_blackboard_id", std::string("polygon_frame_id"));
 
   // Odometry smoother object for getting current speed
   odom_smoother_ = odom_smoother;


### PR DESCRIPTION
Move the `xx_blackboard_id` parameters to the navigator's namespace. This avoids clashes with other navigators which have the same parameter, but uses a different ID -> Not all navigators must use the same blackboard ID.

Related to https://github.com/ros-navigation/navigation2/pull/5466


Documentation was already updated in https://github.com/ros-navigation/docs.nav2.org/pull/768