### PR TITLE
Add frame_id to poses in visualizer

### DIFF
--- a/opennav_coverage/src/visualizer.cpp
+++ b/opennav_coverage/src/visualizer.cpp
@@ -44,6 +44,7 @@ void Visualizer::visualize(
     auto utm_path = std::make_unique<nav_msgs::msg::Path>(nav_path);
     utm_path->header.frame_id = GLOBAL_FRAME;
     for (unsigned int i = 0; i != utm_path->poses.size(); i++) {
+      utm_path->poses[i].header.frame_id = GLOBAL_FRAME;
       utm_path->poses[i].pose.position.x += ref_pt.getX();
       utm_path->poses[i].pose.position.y += ref_pt.getY();
     }


### PR DESCRIPTION
Adding frame_id to each point of the path inside the visualizer allows a correct visualization on FoxGlove Studio. Without it, it gives a warning and paths can't be visualized