### PR TITLE
use unique IDs for BTs

### DIFF
--- a/opennav_coverage_bt/behavior_trees/navigate_w_basic_complete_coverage.xml
+++ b/opennav_coverage_bt/behavior_trees/navigate_w_basic_complete_coverage.xml
@@ -11,8 +11,8 @@
   This BT shows set polygon usage with the coverage server
 -->
 
-<root BTCPP_format="4" main_tree_to_execute="MainTree">
-  <BehaviorTree ID="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="NavigateWBasicCompleteCoverage">
+  <BehaviorTree ID="NavigateWBasicCompleteCoverage">
     <RateController hz="0.0000001"> <!-- once, for demo -->
       <Sequence name="NavigateWithoutReplanning">
         <!-- May use:

--- a/opennav_coverage_bt/behavior_trees/navigate_w_basic_complete_coverage_nav_to_start.xml
+++ b/opennav_coverage_bt/behavior_trees/navigate_w_basic_complete_coverage_nav_to_start.xml
@@ -11,8 +11,8 @@
   This BT shows set polygon usage with the coverage server
 -->
 
-<root BTCPP_format="4" main_tree_to_execute="MainTree">
-  <BehaviorTree ID="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="NavigateWBasicCompleteCoverageNavToStart">
+  <BehaviorTree ID="NavigateWBasicCompleteCoverageNavToStart">
     <RateController hz="0.0000001"> <!-- once, for demo -->
       <Sequence name="NavigateWithoutReplanning">
         <!-- May use:

--- a/opennav_coverage_bt/behavior_trees/navigate_w_basic_row_complete_coverage.xml
+++ b/opennav_coverage_bt/behavior_trees/navigate_w_basic_row_complete_coverage.xml
@@ -11,8 +11,8 @@
   This BT shows field file usage with the row coverage server
 -->
 
-<root BTCPP_format="4" main_tree_to_execute="MainTree">
-  <BehaviorTree ID="MainTree">
+<root BTCPP_format="4" main_tree_to_execute="NavigateWBasicRowCompleteCoverage">
+  <BehaviorTree ID="NavigateWBasicRowCompleteCoverage">
     <RateController hz="0.0000001"> <!-- once, for demo -->
       <Sequence name="NavigateWithoutReplanning">
         <!-- May use:

--- a/opennav_coverage_navigator/src/coverage_navigator.cpp
+++ b/opennav_coverage_navigator/src/coverage_navigator.cpp
@@ -173,9 +173,9 @@ CoverageNavigator::onPreempt(ActionT::Goal::ConstSharedPtr goal)
 {
   RCLCPP_INFO(logger_, "Received goal preemption request");
 
-  if (goal->behavior_tree == bt_action_server_->getCurrentBTFilename() ||
+  if (goal->behavior_tree == bt_action_server_->getDefaultBTFilenameOrID() ||
     (goal->behavior_tree.empty() &&
-    bt_action_server_->getCurrentBTFilename() == bt_action_server_->getDefaultBTFilename()))
+    bt_action_server_->getDefaultBTFilenameOrID() == bt_action_server_->getDefaultBTFilenameOrID()))
   {
     // if pending goal requests the same BT as the current goal, accept the pending goal
     // if pending goal has an empty behavior_tree field, it requests the default BT file


### PR DESCRIPTION
Small fix to have unique IDs for the BTs in this package, following the migration guideline.
Also replace a removed function.
