### PR TITLE
Changing RC to reference so that the navigator's on completion cb may change result statuses with internal context

### DIFF
--- a/opennav_coverage_navigator/include/opennav_coverage_navigator/coverage_navigator.hpp
+++ b/opennav_coverage_navigator/include/opennav_coverage_navigator/coverage_navigator.hpp
@@ -107,7 +107,7 @@ protected:
    */
   void goalCompleted(
     typename ActionT::Result::SharedPtr result,
-    const nav2_behavior_tree::BtStatus final_bt_status) override;
+    nav2_behavior_tree::BtStatus & final_bt_status) override;
 
   /**
    * @brief Goal pose initialization on the blackboard

--- a/opennav_coverage_navigator/src/coverage_navigator.cpp
+++ b/opennav_coverage_navigator/src/coverage_navigator.cpp
@@ -95,7 +95,7 @@ CoverageNavigator::goalReceived(ActionT::Goal::ConstSharedPtr goal)
 void
 CoverageNavigator::goalCompleted(
   typename ActionT::Result::SharedPtr /*result*/,
-  const nav2_behavior_tree::BtStatus /*final_bt_status*/)
+  nav2_behavior_tree::BtStatus & /*final_bt_status*/)
 {
 }
 


### PR DESCRIPTION
https://github.com/ros-navigation/navigation2/pull/6046