### PR TITLE
Fix Broken isValid Check in Path Components Iterator

### DIFF
--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -372,7 +372,7 @@ public:
    */
   bool isValid()
   {
-    return idx_ <= max_idx_;
+    return idx_ < max_idx_;
   }
 
   /**

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -231,6 +231,9 @@ TEST(UtilsTests, TestPathComponentsIterator)
     i++;
   }
 
+  // validate that our iteration value is equal to the size of the input swath
+  EXPECT_EQ(i, msg.swaths.size());
+
   auto last_row_info = it.getNext();
   EXPECT_EQ(std::get<1>(last_row_info), nullptr);
 }


### PR DESCRIPTION
This is a really really simple PR to fix the isValid check #102 

closes #102 