### PR TITLE
docs(doxygen): add XML usage examples for BT nodes

### DIFF
--- a/opennav_coverage_bt/include/opennav_coverage_bt/cancel_complete_coverage_path.hpp
+++ b/opennav_coverage_bt/include/opennav_coverage_bt/cancel_complete_coverage_path.hpp
@@ -28,6 +28,11 @@ namespace opennav_coverage_bt
 /**
  * @brief A nav2_behavior_tree::BtActionNode class that wraps
  * opennav_coverage_msgs::action::ComputeCoveragePath
+ *
+ * Usage in XML:
+ * @code
+ * <CancelCoverage server_name="compute_complete_coverage" server_timeout="10"/>
+ * @endcode
  */
 class CoverageCancel
   : public nav2_behavior_tree::BtCancelActionNode<

--- a/opennav_coverage_bt/include/opennav_coverage_bt/compute_complete_coverage_path.hpp
+++ b/opennav_coverage_bt/include/opennav_coverage_bt/compute_complete_coverage_path.hpp
@@ -29,6 +29,13 @@ namespace opennav_coverage_bt
 
 /**
  * @brief nav2_behavior_tree::BtActionNode class that wraps nav2_msgs::action::ComputeCoveragePath
+ *
+ * Usage in XML:
+ * @code
+ * <ComputeCoveragePath file_field="{field_filepath}" nav_path="{path}" coverage_path="{cov_path}"
+ *                      server_name="ComputeCoverage" server_timeout="10"
+ *                      error_code_id="{compute_coverage_error_code}" error_msg="{compute_coverage_error_msg}"/>
+ * @endcode
  */
 class ComputeCoveragePathAction
   : public nav2_behavior_tree::BtActionNode<


### PR DESCRIPTION
Added usage examples to Doxygen description for BT Node classes, in addition to the Nav2 PR (https://github.com/ros-navigation/navigation2/pull/6101).