### PR TITLE
Bump C++ version from 17 to 20 to match nav2 Lyrical

### DIFF
--- a/opennav_coverage/CMakeLists.txt
+++ b/opennav_coverage/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(opennav_coverage_msgs REQUIRED)
 find_package(Fields2Cover REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference)
 
 include_directories(

--- a/opennav_coverage_bt/CMakeLists.txt
+++ b/opennav_coverage_bt/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(opennav_coverage_msgs REQUIRED)
 find_package(behaviortree_cpp REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference)
 
 include_directories(

--- a/opennav_coverage_navigator/CMakeLists.txt
+++ b/opennav_coverage_navigator/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(geometry_msgs REQUIRED)
 find_package(opennav_coverage_msgs REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wnull-dereference)
 
 include_directories(

--- a/opennav_row_coverage/CMakeLists.txt
+++ b/opennav_row_coverage/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(opennav_coverage_msgs REQUIRED)
 find_package(tinyxml2 REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference)
 
 include_directories(


### PR DESCRIPTION
Fixes #106

Bumps CMAKE_CXX_STANDARD from 17 to 20 to match nav2 main. 