### PR TITLE
Migrate to Fields2Cover v2 (jazzy)

### DIFF
--- a/.github/deps.repos
+++ b/.github/deps.repos
@@ -2,4 +2,4 @@ repositories:
   Fields2Cover:
     type: git
     url: https://github.com/Fields2Cover/Fields2Cover.git
-    version: v1.2.1-devel
+    version: v2.0.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
           linter: [copyright, xmllint, cpplint, uncrustify, pep257, flake8]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ros-tooling/action-ros-lint@v0.1
       with:
         linter: ${{ matrix.linter }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,12 @@ jobs:
       matrix:
           ros_distro: [jazzy]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Cyclone DDS
       run: sudo apt install ros-${{ matrix.ros_distro }}-rmw-cyclonedds-cpp -y
     - name: Build and run tests
       id: action-ros-ci
-      uses: ros-tooling/action-ros-ci@v0.3
+      uses: ros-tooling/action-ros-ci@v0.4
       with:
         import-token: ${{ secrets.GITHUB_TOKEN }}
         target-ros2-distro: ${{ matrix.ros_distro }}

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,10 @@ cmake-build-debug/
 
 # doxygen docs
 doc/html/
+
+.devcontainer
+
+F2C_V2_MIGRATION_AUDIT.md
+F2C_V2_GUNCELLEME_VE_YENI_OZELLIKLER.md
+F2C_V2_MAIN_MIGRATION_PLAN.md
+Fields2Cover/

--- a/README.md
+++ b/README.md
@@ -36,12 +36,13 @@ https://github.com/user-attachments/assets/e44d8f10-c5b0-4345-81ad-25f3bcd06030
 
 ### Fields2Cover Installation
 
-opennav_coverage works with Field2Cover v1.2.1. The newest version v2.0.0 is not supported at the moment.
+> **Note:** This `jazzy` branch targets **Fields2Cover v2** (verified against `v2.0.0`).
 
-To install Fields2Cover, clone it into a colcon workspace and build with `colcon build`.
+opennav_coverage requires Fields2Cover v2.0.0. Clone it into a colcon workspace and build with `colcon build`:
 
-- Humble & Iron: Use tag `v1.2.1`
-- Jazzy & rolling: Use branch `v1.2.1-devel`
+```bash
+git clone --branch v2.0.0 https://github.com/Fields2Cover/Fields2Cover.git
+```
 
 ## Interfaces
 

--- a/opennav_coverage/CMakeLists.txt
+++ b/opennav_coverage/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(opennav_coverage_msgs REQUIRED)
 find_package(Fields2Cover REQUIRED)
+find_package(GDAL REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
 set(CMAKE_CXX_STANDARD 17)
@@ -59,7 +60,23 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-target_link_libraries(${library_name} Fields2Cover)
+# Fields2Cover exposes a different target name depending on the install method
+# (source install: Fields2Cover; ROS/apt package: Fields2Cover::Fields2Cover).
+if(TARGET Fields2Cover::Fields2Cover)
+  set(FIELDS2COVER_LIBRARIES Fields2Cover::Fields2Cover)
+else()
+  set(FIELDS2COVER_LIBRARIES Fields2Cover)
+endif()
+
+target_link_libraries(${library_name} ${FIELDS2COVER_LIBRARIES} GDAL::GDAL)
+
+# Treat Fields2Cover headers as SYSTEM so their own warnings (e.g. -Wshadow in
+# objectives/rp_obj/*) do not break this project's -Werror build. Uses the
+# config-provided include variable, so it is both path-agnostic (apt /opt/ros
+# or source /usr/local) and independent of the target name.
+if(Fields2Cover_INCLUDE_DIR)
+  target_include_directories(${library_name} SYSTEM PUBLIC ${Fields2Cover_INCLUDE_DIR})
+endif()
 
 add_executable(${executable_name}
   src/main.cpp

--- a/opennav_coverage/include/opennav_coverage/robot_params.hpp
+++ b/opennav_coverage/include/opennav_coverage/robot_params.hpp
@@ -44,19 +44,19 @@ public:
   {
     nav2_util::declare_parameter_if_not_declared(
       node, "robot_width", rclcpp::ParameterValue(2.1));
-    robot_.robot_width = node->get_parameter("robot_width").as_double();
+    robot_.setWidth(node->get_parameter("robot_width").as_double());
 
     nav2_util::declare_parameter_if_not_declared(
       node, "operation_width", rclcpp::ParameterValue(2.5));
-    robot_.op_width = node->get_parameter("operation_width").as_double();
+    robot_.setCovWidth(node->get_parameter("operation_width").as_double());
 
     nav2_util::declare_parameter_if_not_declared(
       node, "min_turning_radius", rclcpp::ParameterValue(0.4));
-    robot_.setMinRadius(node->get_parameter("min_turning_radius").as_double());
+    robot_.setMinTurningRadius(node->get_parameter("min_turning_radius").as_double());
 
     nav2_util::declare_parameter_if_not_declared(
       node, "linear_curv_change", rclcpp::ParameterValue(2.0));
-    robot_.linear_curv_change = node->get_parameter("linear_curv_change").as_double();
+    robot_.setMaxDiffCurv(node->get_parameter("linear_curv_change").as_double());
   }
 
   /**
@@ -65,7 +65,7 @@ public:
    */
   double getWidth()
   {
-    return robot_.robot_width;
+    return robot_.getWidth();
   }
 
   /**
@@ -74,7 +74,7 @@ public:
    */
   double getOperationWidth()
   {
-    return robot_.op_width;
+    return robot_.getCovWidth();
   }
 
   /**

--- a/opennav_coverage/include/opennav_coverage/types.hpp
+++ b/opennav_coverage/include/opennav_coverage/types.hpp
@@ -35,7 +35,6 @@ typedef F2CRobot Robot;
 typedef F2CLinearRing Polygon;
 typedef F2CPoint Point;
 typedef f2c::types::PathState PathState;
-typedef f2c::types::LineString LineString;
 typedef F2CLineString LineString;
 
 typedef std::shared_ptr<f2c::hg::HeadlandGeneratorBase> HeadlandGeneratorPtr;

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -128,7 +128,7 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
   msg.swaths_ordered = true;
   msg.header = header;
 
-  if (raw_path.states.size() == 0) {
+  if (raw_path.size() == 0) {
     return msg;
   }
 
@@ -142,45 +142,45 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
     path.moveTo(field.getRefPoint());
   }
 
-  PathSectionType curr_state = path.states[0].type;
+  PathSectionType curr_state = path[0].type;
   if (curr_state == PathSectionType::SWATH) {
-    curr_swath_start = path.states[0].point;
+    curr_swath_start = path[0].point;
   } else if (curr_state == PathSectionType::TURN) {
     msg.turns.push_back(nav_msgs::msg::Path());
     msg.turns.back().header = header;
     curr_turn = &msg.turns.back();
   }
 
-  for (unsigned int i = 0; i != path.states.size(); i++) {
-    if (curr_state == path.states[i].type && path.states[i].type == PathSectionType::SWATH) {
+  for (unsigned int i = 0; i != path.size(); i++) {
+    if (curr_state == path[i].type && path[i].type == PathSectionType::SWATH) {
       // Continuing swath so...
       // (1) no action required.
-    } else if (curr_state == path.states[i].type && path.states[i].type == PathSectionType::TURN) {
+    } else if (curr_state == path[i].type && path[i].type == PathSectionType::TURN) {
       // Continuing a turn so...
       // (1) keep populating
-      curr_turn->poses.push_back(toMsg(path.states[i]));
-    } else if (curr_state != path.states[i].type && path.states[i].type == PathSectionType::TURN) {
+      curr_turn->poses.push_back(toMsg(path[i]));
+    } else if (curr_state != path[i].type && path[i].type == PathSectionType::TURN) {
       // Transitioning from a swath to a turn so...
       // (1) Complete the existing swath
       opennav_coverage_msgs::msg::Swath swath;
       swath.start = toMsg(curr_swath_start);
-      swath.end = toMsg(path.states[i - 1].point);
+      swath.end = toMsg(path[i - 1].point);
       msg.swaths.push_back(swath);
       // (2) Start a new turn path
       msg.turns.push_back(nav_msgs::msg::Path());
       msg.turns.back().header = header;
       curr_turn = &msg.turns.back();
-      curr_turn->poses.push_back(toMsg(path.states[i]));
-    } else if (curr_state != path.states[i].type && path.states[i].type == PathSectionType::SWATH) {
+      curr_turn->poses.push_back(toMsg(path[i]));
+    } else if (curr_state != path[i].type && path[i].type == PathSectionType::SWATH) {
       // Transitioning from a turn to a swath so...
       // (1) Update new swath starting point
-      curr_swath_start = path.states[i].point;
+      curr_swath_start = path[i].point;
     }
 
-    curr_state = path.states[i].type;
+    curr_state = path[i].type;
 
-    if (path.states[i].type != PathSectionType::SWATH &&
-      path.states[i].type != PathSectionType::TURN)
+    if (path[i].type != PathSectionType::SWATH &&
+      path[i].type != PathSectionType::TURN)
     {
       throw std::runtime_error("Unknown type of path state detected, cannot obtain path!");
     }
@@ -189,7 +189,7 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
   if (curr_state == PathSectionType::SWATH) {
     opennav_coverage_msgs::msg::Swath swath;
     swath.start = toMsg(curr_swath_start);
-    swath.end = toMsg(path.states.back().point);
+    swath.end = toMsg(path.back().point);
     msg.swaths.push_back(swath);
   }
 
@@ -215,7 +215,7 @@ inline nav_msgs::msg::Path toNavPathMsg(
   nav_msgs::msg::Path msg;
   msg.header = header;
 
-  if (raw_path.states.size() == 0) {
+  if (raw_path.size() == 0) {
     return msg;
   }
 
@@ -226,15 +226,15 @@ inline nav_msgs::msg::Path toNavPathMsg(
     path.moveTo(field.getRefPoint());
   }
 
-  for (unsigned int i = 0; i != path.states.size(); i++) {
+  for (unsigned int i = 0; i != path.size(); i++) {
     // Swaths come in pairs of start-end sequentially
-    if (i > 0 && path.states[i].type == PathSectionType::SWATH &&
-      path.states[i - 1].type == PathSectionType::SWATH)
+    if (i > 0 && path[i].type == PathSectionType::SWATH &&
+      path[i - 1].type == PathSectionType::SWATH)
     {
-      const float & x0 = path.states[i - 1].point.getX();
-      const float & y0 = path.states[i - 1].point.getY();
-      const float & x1 = path.states[i].point.getX();
-      const float & y1 = path.states[i].point.getY();
+      const float & x0 = path[i - 1].point.getX();
+      const float & y0 = path[i - 1].point.getY();
+      const float & x1 = path[i].point.getX();
+      const float & y1 = path[i].point.getY();
 
       const float dist = hypotf(x1 - x0, y1 - y0);
       const float ux = (x1 - x0) / dist;
@@ -243,10 +243,10 @@ inline nav_msgs::msg::Path toNavPathMsg(
 
       geometry_msgs::msg::PoseStamped pose;
       pose.pose.orientation =
-        nav2_util::geometry_utils::orientationAroundZAxis(path.states[i].angle);
+        nav2_util::geometry_utils::orientationAroundZAxis(path[i].angle);
       pose.pose.position.x = x0;
       pose.pose.position.y = y0;
-      pose.pose.position.z = path.states[i].point.getZ();
+      pose.pose.position.z = path[i].point.getZ();
 
       while (curr_dist < dist) {
         pose.pose.position.x += pt_dist * ux;
@@ -256,7 +256,7 @@ inline nav_msgs::msg::Path toNavPathMsg(
       }
     } else {
       // Turns are already dense paths
-      msg.poses.push_back(toMsg(path.states[i]));
+      msg.poses.push_back(toMsg(path[i]));
     }
   }
 

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -175,7 +175,7 @@ void CoverageServer::computeCoveragePath()
     std::string frame_id;
     if (goal->use_gml_file) {
       master_field = f2c::Parser::importFieldGml(goal->gml_field, true);
-      frame_id = master_field.coord_sys;
+      frame_id = master_field.getCRS();
     } else {
       master_field = util::getFieldFromGoal(goal);
       master_field.setCRS(goal->frame_id);
@@ -185,7 +185,7 @@ void CoverageServer::computeCoveragePath()
     if (!cartesian_frame_) {
       f2c::Transform::transformToUTM(master_field);
     }
-    field = master_field.field.getGeometry(0);
+    field = master_field.getField().getGeometry(0);
 
     RCLCPP_INFO(
       get_logger(),

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -269,10 +269,10 @@ CoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramet
         path_gen_->setTurnPointDistance(parameter.as_double());
       } else if (name == "robot_width") {
         auto & robot = robot_params_->getRobot();
-        robot.robot_width = parameter.as_double();
+        robot.setWidth(parameter.as_double());
       } else if (name == "operation_width") {
         auto & robot = robot_params_->getRobot();
-        robot.op_width = parameter.as_double();
+        robot.setCovWidth(parameter.as_double());
       }
     } else if (type == ParameterType::PARAMETER_STRING) {
       if (name == "default_headland_type") {

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -46,8 +46,8 @@ Path PathGenerator::generatePath(
   RCLCPP_DEBUG(
     logger_,
     "Generating path with curve: %s", toString(action_type, action_continuity_type).c_str());
-  generator_->turn_point_dist = turn_point_distance;
-  return generator_->searchBestPath(robot_params_->getRobot(), swaths, *curve);
+  curve->setDiscretization(turn_point_distance);
+  return generator_->planPath(robot_params_->getRobot(), swaths, *curve);
 }
 
 void PathGenerator::setPathMode(const std::string & new_mode)

--- a/opennav_coverage/src/swath_generator.cpp
+++ b/opennav_coverage/src/swath_generator.cpp
@@ -51,7 +51,7 @@ Swaths SwathGenerator::generateSwaths(
       if (!objective) {
         throw CoverageException("No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE.");
       }
-      generator_->step_angle = step_angle;
+      generator_->setStepAngle(step_angle);
       return generator_->generateBestSwaths(*objective, robot_params_->getOperationWidth(), field);
     case SwathAngleType::SET_ANGLE:
       return generator_->generateSwaths(swath_angle, robot_params_->getOperationWidth(), field);

--- a/opennav_coverage/test/test_headland.cpp
+++ b/opennav_coverage/test/test_headland.cpp
@@ -80,13 +80,13 @@ TEST(HeadlandTests, TestheadlandGeneration)
 
   // Generate some toy field
   f2c::Random rand;
-  auto field = rand.generateRandField(5, 1e5);
+  auto field = rand.generateRandField(1e5, 5);
 
   // Shouldn't throw, results in valid output
   opennav_coverage_msgs::msg::HeadlandMode settings;
-  auto field_out = generator.generateHeadlands(field.field.getGeometry(0), settings);
+  auto field_out = generator.generateHeadlands(field.getField().getGeometry(0), settings);
   settings.mode = "CONSTANT";
-  auto field_out2 = generator.generateHeadlands(field.field.getGeometry(0), settings);
+  auto field_out2 = generator.generateHeadlands(field.getField().getGeometry(0), settings);
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_path.cpp
+++ b/opennav_coverage/test/test_path.cpp
@@ -114,9 +114,9 @@ TEST(PathTests, TestpathGeneration)
 
   // Generate some toy route
   f2c::Random rand;
-  auto field = rand.generateRandField(5, 1e5);
+  auto field = rand.generateRandField(1e5, 5);
   opennav_coverage_msgs::msg::SwathMode sw_settings;
-  auto swaths = swath_gen.generateSwaths(field.field.getGeometry(0), sw_settings);
+  auto swaths = swath_gen.generateSwaths(field.getField().getGeometry(0), sw_settings);
   opennav_coverage_msgs::msg::RouteMode rt_settings;
   auto route = route_gen.generateRoute(swaths, rt_settings);
 

--- a/opennav_coverage/test/test_robot.cpp
+++ b/opennav_coverage/test/test_robot.cpp
@@ -37,7 +37,7 @@ TEST(RobotTests, Testrobot)
 
   EXPECT_EQ(robot.getWidth(), 2.1);
   EXPECT_EQ(robot.getOperationWidth(), 2.5);
-  EXPECT_EQ(robot.getRobot().linear_curv_change, 2.0);
+  EXPECT_EQ(robot.getRobot().getMaxDiffCurv(), 2.0);
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_route.cpp
+++ b/opennav_coverage/test/test_route.cpp
@@ -99,8 +99,8 @@ TEST(RouteTests, TestrouteGeneration)
 
   // Generate some toy field
   f2c::Random rand;
-  auto field = rand.generateRandField(5, 1e5);
-  auto swaths = swath_gen.generateSwaths(field.field.getGeometry(0), sw_settings);
+  auto field = rand.generateRandField(1e5, 5);
+  auto swaths = swath_gen.generateSwaths(field.getField().getGeometry(0), sw_settings);
 
   // Shouldn't throw, results in valid output
   opennav_coverage_msgs::msg::RouteMode settings;

--- a/opennav_coverage/test/test_swath.cpp
+++ b/opennav_coverage/test/test_swath.cpp
@@ -108,17 +108,17 @@ TEST(SwathTests, TestswathGeneration)
 
   // Generate some toy field
   f2c::Random rand;
-  auto field = rand.generateRandField(5, 1e5);
+  auto field = rand.generateRandField(1e5, 5);
 
   // Shouldn't throw, results in valid output
   opennav_coverage_msgs::msg::SwathMode settings;
-  auto swaths1 = generator.generateSwaths(field.field.getGeometry(0), settings);
+  auto swaths1 = generator.generateSwaths(field.getField().getGeometry(0), settings);
   settings.mode = "BRUTE_FORCE";
   settings.objective = "LENGTH";
-  auto swaths2 = generator.generateSwaths(field.field.getGeometry(0), settings);
+  auto swaths2 = generator.generateSwaths(field.getField().getGeometry(0), settings);
   settings.mode = "SET_ANGLE";
   settings.objective = "NUMBER";
-  auto swaths3 = generator.generateSwaths(field.field.getGeometry(0), settings);
+  auto swaths3 = generator.generateSwaths(field.getField().getGeometry(0), settings);
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -105,7 +105,12 @@ TEST(UtilsTests, TesttoNavPathMsg)
   std_msgs::msg::Header header_in;
   header_in.frame_id = "test";
   Path path_in;
-  path_in.states.resize(10);
+  path_in.getStates().resize(10);
+  // v2 default-initializes PathState::type to SWATH; mark as TURN so each state
+  // yields one pose (consecutive SWATHs at the same point would densify to one).
+  for (auto & state : path_in.getStates()) {
+    state.type = f2c::types::PathSectionType::TURN;
+  }
   F2CField field;
 
   auto msg = util::toNavPathMsg(path_in, field, header_in, true, 0.1);
@@ -126,38 +131,40 @@ TEST(UtilsTests, TesttoCoveragePathMsg2)
   EXPECT_EQ(msg.contains_turns, true);
   EXPECT_EQ(msg.swaths_ordered, true);
 
-  // states are not valid (e.g. non-marked as turn or swath)
-  path_in.states.resize(10);
+  // states are not valid (e.g. non-marked as turn or swath). v2 defaults type to
+  // SWATH, so explicitly set an unhandled type (HL_SWATH) to trigger the error.
+  path_in.getStates().resize(10);
+  path_in.getStates()[0].type = f2c::types::PathSectionType::HL_SWATH;
   EXPECT_THROW(util::toCoveragePathMsg(path_in, field, header_in, true), std::runtime_error);
 
   // Now lets make it valid
   using f2c::types::PathSectionType;
-  path_in.states[0].type = PathSectionType::SWATH;
-  path_in.states[1].type = PathSectionType::SWATH;
-  path_in.states[2].type = PathSectionType::TURN;
-  path_in.states[3].type = PathSectionType::TURN;
-  path_in.states[4].type = PathSectionType::SWATH;
-  path_in.states[5].type = PathSectionType::SWATH;
-  path_in.states[6].type = PathSectionType::TURN;
-  path_in.states[7].type = PathSectionType::TURN;
-  path_in.states[8].type = PathSectionType::SWATH;
-  path_in.states[9].type = PathSectionType::SWATH;
+  path_in.getStates()[0].type = PathSectionType::SWATH;
+  path_in.getStates()[1].type = PathSectionType::SWATH;
+  path_in.getStates()[2].type = PathSectionType::TURN;
+  path_in.getStates()[3].type = PathSectionType::TURN;
+  path_in.getStates()[4].type = PathSectionType::SWATH;
+  path_in.getStates()[5].type = PathSectionType::SWATH;
+  path_in.getStates()[6].type = PathSectionType::TURN;
+  path_in.getStates()[7].type = PathSectionType::TURN;
+  path_in.getStates()[8].type = PathSectionType::SWATH;
+  path_in.getStates()[9].type = PathSectionType::SWATH;
 
   msg = util::toCoveragePathMsg(path_in, field, header_in, true);
   EXPECT_EQ(msg.swaths.size(), 3u);
   EXPECT_EQ(msg.turns.size(), 2u);
   EXPECT_EQ(msg.turns[0].poses.size(), 2u);
 
-  path_in.states[0].type = PathSectionType::TURN;
-  path_in.states[1].type = PathSectionType::TURN;
-  path_in.states[2].type = PathSectionType::SWATH;
-  path_in.states[3].type = PathSectionType::SWATH;
-  path_in.states[4].type = PathSectionType::TURN;
-  path_in.states[5].type = PathSectionType::TURN;
-  path_in.states[6].type = PathSectionType::SWATH;
-  path_in.states[7].type = PathSectionType::SWATH;
-  path_in.states[8].type = PathSectionType::TURN;
-  path_in.states[9].type = PathSectionType::TURN;
+  path_in.getStates()[0].type = PathSectionType::TURN;
+  path_in.getStates()[1].type = PathSectionType::TURN;
+  path_in.getStates()[2].type = PathSectionType::SWATH;
+  path_in.getStates()[3].type = PathSectionType::SWATH;
+  path_in.getStates()[4].type = PathSectionType::TURN;
+  path_in.getStates()[5].type = PathSectionType::TURN;
+  path_in.getStates()[6].type = PathSectionType::SWATH;
+  path_in.getStates()[7].type = PathSectionType::SWATH;
+  path_in.getStates()[8].type = PathSectionType::TURN;
+  path_in.getStates()[9].type = PathSectionType::TURN;
 
   msg = util::toCoveragePathMsg(path_in, field, header_in, true);
   EXPECT_EQ(msg.swaths.size(), 2u);
@@ -181,7 +188,7 @@ TEST(UtilsTests, TestgetFieldFromGoal)
   // Should work now, with a trivial polygon of 3 nodes of (0, 0)
   goal->polygons[0].coordinates[2].axis1 = 0.0;
   auto field = util::getFieldFromGoal(goal);
-  EXPECT_EQ(field.field.getGeometry(0).getGeometry(0).size(), 3u);
+  EXPECT_EQ(field.getField().getGeometry(0).getGeometry(0).size(), 3u);
 
   // Test with inner polygons, first invalid
   goal->polygons.resize(2);
@@ -193,7 +200,7 @@ TEST(UtilsTests, TestgetFieldFromGoal)
   goal->polygons[0].coordinates[0].axis1 = 0.0;
   goal->polygons[1].coordinates[0].axis1 = 1.0;
   auto field2 = util::getFieldFromGoal(goal);
-  EXPECT_EQ(field2.field.getGeometry(0).getGeometry(1).size(), 3u);
+  EXPECT_EQ(field2.getField().getGeometry(0).getGeometry(1).size(), 3u);
 }
 
 TEST(UtilsTests, TestPathComponentsIterator)

--- a/opennav_row_coverage/CMakeLists.txt
+++ b/opennav_row_coverage/CMakeLists.txt
@@ -7,9 +7,11 @@ find_package(rclcpp_components REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(nav2_util REQUIRED)
 find_package(Fields2Cover REQUIRED)
+find_package(GDAL REQUIRED)
 find_package(opennav_coverage REQUIRED)
 find_package(opennav_coverage_msgs REQUIRED)
-find_package(tinyxml2 REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
+find_package(TinyXML2 REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
 set(CMAKE_CXX_STANDARD 17)
@@ -46,7 +48,22 @@ ament_target_dependencies(${library_name}
   ${dependencies}
 )
 
-target_link_libraries(${library_name} Fields2Cover tinyxml2::tinyxml2)
+# Fields2Cover exposes a different target name depending on the install method
+# (source install: Fields2Cover; ROS/apt package: Fields2Cover::Fields2Cover).
+if(TARGET Fields2Cover::Fields2Cover)
+  set(FIELDS2COVER_LIBRARIES Fields2Cover::Fields2Cover)
+else()
+  set(FIELDS2COVER_LIBRARIES Fields2Cover)
+endif()
+
+target_link_libraries(${library_name} ${FIELDS2COVER_LIBRARIES} tinyxml2::tinyxml2 GDAL::GDAL)
+
+# Treat Fields2Cover headers as SYSTEM so their own warnings do not break this
+# project's -Werror build. Uses the config-provided include variable (path- and
+# target-name-agnostic; apt /opt/ros or source /usr/local).
+if(Fields2Cover_INCLUDE_DIR)
+  target_include_directories(${library_name} SYSTEM PUBLIC ${Fields2Cover_INCLUDE_DIR})
+endif()
 
 add_executable(${executable_name}
   src/main.cpp
@@ -58,7 +75,7 @@ ament_target_dependencies(${executable_name}
   ${dependencies}
 )
 
-target_link_libraries(${executable_name} Fields2Cover tinyxml2::tinyxml2)
+target_link_libraries(${executable_name} ${FIELDS2COVER_LIBRARIES} tinyxml2::tinyxml2 GDAL::GDAL)
 
 rclcpp_components_register_nodes(${library_name} "opennav_row_coverage::RowCoverageServer")
 

--- a/opennav_row_coverage/package.xml
+++ b/opennav_row_coverage/package.xml
@@ -14,7 +14,7 @@
   <depend>fields2cover</depend>
   <depend>opennav_coverage</depend>
   <depend>opennav_coverage_msgs</depend>
-  <depend>tinyxml2</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -263,10 +263,10 @@ RowCoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> para
         path_gen_->setTurnPointDistance(parameter.as_double());
       } else if (name == "robot_width") {
         auto & robot = robot_params_->getRobot();
-        robot.robot_width = parameter.as_double();
+        robot.setWidth(parameter.as_double());
       } else if (name == "operation_width") {
         auto & robot = robot_params_->getRobot();
-        robot.op_width = parameter.as_double();
+        robot.setCovWidth(parameter.as_double());
       } else if (name == "default_offset") {
         swath_gen_->setOffset(parameter.as_double());
       }

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -180,7 +180,7 @@ void RowCoverageServer::computeCoveragePath()
     // (0) Obtain field and rows to use
     F2CField master_field = f2c::Parser::importFieldGml(goal->gml_field, true);
     Rows rows = util::parseRows(goal->gml_field, order_ids_);
-    std::string frame_id = master_field.coord_sys;
+    std::string frame_id = master_field.getCRS();
 
     if (!cartesian_frame_) {
       f2c::Transform::transformToUTM(master_field);
@@ -188,7 +188,7 @@ void RowCoverageServer::computeCoveragePath()
     } else {
       rows = util::removeRowsRefPoint(rows, master_field);
     }
-    Field field = master_field.field.getGeometry(0);
+    Field field = master_field.getField().getGeometry(0);
 
     RCLCPP_INFO(
       get_logger(),

--- a/opennav_row_coverage/src/row_swath_generator.cpp
+++ b/opennav_row_coverage/src/row_swath_generator.cpp
@@ -176,7 +176,7 @@ Rows RowSwathGenerator::adjustRowOrientations(const Rows & input_rows)
   Rows rows = input_rows;
 
   auto unitVectorize = [&](const Row & row) {
-      Point v = row.first.EndPoint() - row.first.StartPoint();
+      Point v = row.first.endPoint() - row.first.startPoint();
       double normalize = 1.0 / std::sqrt(
         v.getX() * v.getX() + v.getY() * v.getY());
       return v * normalize;


### PR DESCRIPTION
## Summary

Ports the Fields2Cover 1.2.1 → v2.0.0 migration to the `jazzy` branch, matching the equivalent work already done on `humble-v2` (PR #105).

- **A.1** Remove duplicate `LineString` typedef in `types.hpp`
- **A.2** Migrate `F2CRobot` field access to v2 getter/setter API (`setWidth`, `setCovWidth`, `setMinTurningRadius`, `setMaxDiffCurv`)
- **A.3** Use `BruteForce::setStepAngle` instead of public `step_angle` field
- **A.4** Use `PathPlanning::planPath` and `TurningBase::setDiscretization` (replaces `searchBestPath` + `turn_point_dist`)
- **A.7** Use `F2CField::getCRS()` / `getField()` accessors (replaces `coord_sys` / `.field` direct access)
- **A.8** Access `Path` states via `operator[]` / `size()` / `back()` (replaces `path.states[i]`)
- **A.11** Rename `LineString` `StartPoint`/`EndPoint` → camelCase
- **A.12/A.13** Update build system (`find_package(GDAL)`, `GDAL::GDAL` link, `if(TARGET Fields2Cover::Fields2Cover)` guard, `SYSTEM` include for `-Wshadow`/`-Werror`, `tinyxml2_vendor` module-mode fix) and migrate tests
- Pin `Fields2Cover` in `deps.repos` to `v2.0.0`, bump `actions/checkout` v2→v4 and `action-ros-ci` v0.3→v0.4

The jazzy branch is structurally close to humble (still `nav2_util`, C++17), so all 9 commits applied cleanly via cherry-pick with no conflicts.

## Test plan

- [ ] CI passes on jazzy / Ubuntu Noble
- [ ] `colcon build --packages-select opennav_coverage_msgs opennav_coverage opennav_row_coverage` succeeds
- [ ] `colcon test --packages-select opennav_coverage opennav_row_coverage` passes (207 tests expected, matching humble-v2 baseline)

Related: PR #105 (humble-v2), main branch migration PR