### PR TITLE
Add task time, per-pose velocity/direction, and NSwathModified swath objective

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,14 @@ jobs:
       #   key resolves to a ROS ompl whose API nav2 main doesn't match (see below).
       # backward-ros: nav2 build dependency; install explicitly so a transient
       #   rosdep gap can't fail the nav2 configure (seen in the rolling dev container).
+      # ament-cmake-vendor-package: build helper the *_vendor packages need on
+      #   rolling; a rosdep gap can leave it missing and fail their configure.
+      # libopenblas-dev: Fields2Cover builds matplot from source, which links
+      #   against OpenBLAS (-lopenblas). The resolute image no longer ships the
+      #   dev symlink, so provide /usr/lib/.../libopenblas.so or the link fails.
+      # message-filters: the resolute image's older message_filters lacks
+      #   systemClockNow(), which the newer point_cloud_transport it also ships
+      #   needs -- nav2_costmap_2d fails to link. Pull the current one to match.
       # The rest: Fields2Cover (gdal/eigen/geos/tinyxml2), tinyxml2-vendor for
       #   opennav_row_coverage, Cyclone DDS, and vcstool/colcon.
       run: |
@@ -47,7 +55,10 @@ jobs:
           ros-${{ matrix.ros_distro }}-rmw-cyclonedds-cpp \
           ros-${{ matrix.ros_distro }}-tinyxml2-vendor \
           ros-${{ matrix.ros_distro }}-backward-ros \
-          libgdal-dev libeigen3-dev libgeos-dev libtinyxml2-dev libompl-dev
+          ros-${{ matrix.ros_distro }}-ament-cmake-vendor-package \
+          ros-${{ matrix.ros_distro }}-message-filters \
+          libgdal-dev libeigen3-dev libgeos-dev libtinyxml2-dev libompl-dev \
+          libopenblas-dev
 
     - name: Restore colcon cache
       id: colcon_cache

--- a/opennav_coverage/CMakeLists.txt
+++ b/opennav_coverage/CMakeLists.txt
@@ -22,7 +22,9 @@ find_package(GDAL REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
 set(CMAKE_CXX_STANDARD 20)
-add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference)
+# -Wno-error=null-dereference: GCC false-positives on inlined ROS2 message
+# operator==/!= (e.g. coordinate__struct.hpp) when included via getFieldFromGoal().
+add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference -Wno-error=null-dereference)
 
 include_directories(
   include

--- a/opennav_coverage/CMakeLists.txt
+++ b/opennav_coverage/CMakeLists.txt
@@ -22,8 +22,6 @@ find_package(GDAL REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
 set(CMAKE_CXX_STANDARD 20)
-# -Wno-error=null-dereference: GCC false-positives on inlined ROS2 message
-# operator==/!= (e.g. coordinate__struct.hpp) when included via getFieldFromGoal().
 add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference -Wno-error=null-dereference)
 
 include_directories(

--- a/opennav_coverage/include/opennav_coverage/types.hpp
+++ b/opennav_coverage/include/opennav_coverage/types.hpp
@@ -61,7 +61,8 @@ enum class SwathType
   UNKNOWN = 0,
   LENGTH = 1,
   NUMBER = 2,
-  COVERAGE = 3
+  COVERAGE = 3,
+  NUMBER_MODIFIED = 4
 };
 
 /**

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -237,6 +237,44 @@ inline nav_msgs::msg::Path toNavPathMsg(
 }
 
 /**
+ * @brief Overload of toNavPathMsg that also populates per-pose velocity and direction vectors,
+ * parallel to the returned nav_path.poses. Vectors are cleared before filling.
+ */
+inline nav_msgs::msg::Path toNavPathMsg(
+  const Path & raw_path, const F2CField & field,
+  const std_msgs::msg::Header & header, const bool is_cartesian,
+  const float & pt_dist,
+  std::vector<double> & out_velocities,
+  std::vector<bool> & out_is_backward)
+{
+  nav_msgs::msg::Path msg;
+  msg.header = header;
+  out_velocities.clear();
+  out_is_backward.clear();
+
+  if (raw_path.size() == 0) {
+    return msg;
+  }
+
+  Path path = raw_path;
+  if (!is_cartesian) {
+    path = f2c::Transform::transformToPrevCRS(raw_path, field);
+  } else {
+    path.moveTo(field.getRefPoint());
+  }
+
+  path = path.discretizeSwath(static_cast<double>(pt_dist));
+
+  for (const auto & state : path) {
+    msg.poses.push_back(toMsg(state));
+    out_velocities.push_back(state.velocity);
+    out_is_backward.push_back(state.dir == f2c::types::PathDirection::BACKWARD);
+  }
+
+  return msg;
+}
+
+/**
  * @brief Converts full path to nav_msgs/path message in cartesian UTM frame
  * @param path Full path to convert
  * @param header header

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -211,7 +211,6 @@ inline nav_msgs::msg::Path toNavPathMsg(
   const std_msgs::msg::Header & header, const bool is_cartesian,
   const float & pt_dist)
 {
-  using f2c::types::PathSectionType;
   nav_msgs::msg::Path msg;
   msg.header = header;
 
@@ -226,38 +225,12 @@ inline nav_msgs::msg::Path toNavPathMsg(
     path.moveTo(field.getRefPoint());
   }
 
-  for (unsigned int i = 0; i != path.size(); i++) {
-    // Swaths come in pairs of start-end sequentially
-    if (i > 0 && path[i].type == PathSectionType::SWATH &&
-      path[i - 1].type == PathSectionType::SWATH)
-    {
-      const float & x0 = path[i - 1].point.getX();
-      const float & y0 = path[i - 1].point.getY();
-      const float & x1 = path[i].point.getX();
-      const float & y1 = path[i].point.getY();
+  // discretizeSwath splits only SWATH states at step_size intervals; TURN states pass through
+  // unchanged. Do NOT use discretize() — that calls populate()+reduce(), which modifies TURNs.
+  path = path.discretizeSwath(static_cast<double>(pt_dist));
 
-      const float dist = hypotf(x1 - x0, y1 - y0);
-      const float ux = (x1 - x0) / dist;
-      const float uy = (y1 - y0) / dist;
-      float curr_dist = pt_dist;
-
-      geometry_msgs::msg::PoseStamped pose;
-      pose.pose.orientation =
-        nav2_util::geometry_utils::orientationAroundZAxis(path[i].angle);
-      pose.pose.position.x = x0;
-      pose.pose.position.y = y0;
-      pose.pose.position.z = path[i].point.getZ();
-
-      while (curr_dist < dist) {
-        pose.pose.position.x += pt_dist * ux;
-        pose.pose.position.y += pt_dist * uy;
-        msg.poses.push_back(pose);
-        curr_dist += pt_dist;
-      }
-    } else {
-      // Turns are already dense paths
-      msg.poses.push_back(toMsg(path[i]));
-    }
+  for (const auto & state : path) {
+    msg.poses.push_back(toMsg(state));
   }
 
   return msg;

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -231,8 +231,7 @@ inline nav_msgs::msg::Path toNavPathMsg(
     path.moveTo(field.getRefPoint());
   }
 
-  // discretizeSwath splits only SWATH states at step_size intervals; TURN states pass through
-  // unchanged. Do NOT use discretize() — that calls populate()+reduce(), which modifies TURNs.
+  // discretizeSwath splits only SWATH states at step_size intervals
   path = path.discretizeSwath(static_cast<double>(pt_dist));
 
   // Reserve up front so the population loop below doesn't reallocate.

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -204,15 +204,21 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
  * @param Field Field to use for conversion from UTM if necessary
  * @param header header
  * @param bool if the origional CRS is cartesian or not requiring conversion
+ * @param out_velocities Optional: if non-null, filled with per-pose velocity (m/s), parallel to poses
+ * @param out_is_backward Optional: if non-null, filled with per-pose reverse-direction flags
  * @return nav_msgs/Path Path
  */
 inline nav_msgs::msg::Path toNavPathMsg(
   const Path & raw_path, const F2CField & field,
   const std_msgs::msg::Header & header, const bool is_cartesian,
-  const float & pt_dist)
+  const float & pt_dist,
+  std::vector<double> * out_velocities = nullptr,
+  std::vector<bool> * out_is_backward = nullptr)
 {
   nav_msgs::msg::Path msg;
   msg.header = header;
+  if (out_velocities) {out_velocities->clear();}
+  if (out_is_backward) {out_is_backward->clear();}
 
   if (raw_path.size() == 0) {
     return msg;
@@ -229,46 +235,18 @@ inline nav_msgs::msg::Path toNavPathMsg(
   // unchanged. Do NOT use discretize() — that calls populate()+reduce(), which modifies TURNs.
   path = path.discretizeSwath(static_cast<double>(pt_dist));
 
-  for (const auto & state : path) {
-    msg.poses.push_back(toMsg(state));
-  }
-
-  return msg;
-}
-
-/**
- * @brief Overload of toNavPathMsg that also populates per-pose velocity and direction vectors,
- * parallel to the returned nav_path.poses. Vectors are cleared before filling.
- */
-inline nav_msgs::msg::Path toNavPathMsg(
-  const Path & raw_path, const F2CField & field,
-  const std_msgs::msg::Header & header, const bool is_cartesian,
-  const float & pt_dist,
-  std::vector<double> & out_velocities,
-  std::vector<bool> & out_is_backward)
-{
-  nav_msgs::msg::Path msg;
-  msg.header = header;
-  out_velocities.clear();
-  out_is_backward.clear();
-
-  if (raw_path.size() == 0) {
-    return msg;
-  }
-
-  Path path = raw_path;
-  if (!is_cartesian) {
-    path = f2c::Transform::transformToPrevCRS(raw_path, field);
-  } else {
-    path.moveTo(field.getRefPoint());
-  }
-
-  path = path.discretizeSwath(static_cast<double>(pt_dist));
+  // Reserve up front so the population loop below doesn't reallocate.
+  const auto n = path.size();
+  msg.poses.reserve(n);
+  if (out_velocities) {out_velocities->reserve(n);}
+  if (out_is_backward) {out_is_backward->reserve(n);}
 
   for (const auto & state : path) {
     msg.poses.push_back(toMsg(state));
-    out_velocities.push_back(state.velocity);
-    out_is_backward.push_back(state.dir == f2c::types::PathDirection::BACKWARD);
+    if (out_velocities) {out_velocities->push_back(state.velocity);}
+    if (out_is_backward) {
+      out_is_backward->push_back(state.dir == f2c::types::PathDirection::BACKWARD);
+    }
   }
 
   return msg;

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -209,13 +209,9 @@ void CoverageServer::computeCoveragePath()
         path = path_gen_->generatePath(route, goal->path_mode);
         result->coverage_path =
           util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
-        std::vector<double> velocities;
-        std::vector<bool> is_backward;
         result->nav_path = util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
-          velocities, is_backward);
-        result->coverage_path.velocities = velocities;
-        result->coverage_path.is_backward = is_backward;
+          result->coverage_path.velocities, result->coverage_path.is_backward);
         const double task_time = path.getTaskTime();
         result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
+
 #include "opennav_coverage/coverage_server.hpp"
 
 using namespace std::chrono_literals;
@@ -209,6 +211,8 @@ void CoverageServer::computeCoveragePath()
           util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance());
+        const double task_time = path.getTaskTime();
+        result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {
         result->coverage_path =
           util::toCoveragePathMsg(route, master_field, true, header, cartesian_frame_);

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -209,8 +209,13 @@ void CoverageServer::computeCoveragePath()
         path = path_gen_->generatePath(route, goal->path_mode);
         result->coverage_path =
           util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
+        std::vector<double> velocities;
+        std::vector<bool> is_backward;
         result->nav_path = util::toNavPathMsg(
-          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance());
+          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
+          velocities, is_backward);
+        result->coverage_path.velocities = velocities;
+        result->coverage_path.is_backward = is_backward;
         const double task_time = path.getTaskTime();
         result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -211,7 +211,7 @@ void CoverageServer::computeCoveragePath()
           util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
-          result->coverage_path.velocities, result->coverage_path.is_backward);
+          &result->coverage_path.velocities, &result->coverage_path.is_backward);
         const double task_time = path.getTaskTime();
         result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {

--- a/opennav_coverage/src/swath_generator.cpp
+++ b/opennav_coverage/src/swath_generator.cpp
@@ -80,6 +80,8 @@ SwathObjectivePtr SwathGenerator::createObjective(const SwathType & type)
       return std::move(std::make_shared<f2c::obj::NSwath>());
     case SwathType::COVERAGE:
       return std::move(std::make_shared<f2c::obj::FieldCoverage>());
+    case SwathType::NUMBER_MODIFIED:
+      return std::move(std::make_shared<f2c::obj::NSwathModified>());
     default:
       RCLCPP_WARN(logger_, "Unknown swath type set!");
       return SwathObjectivePtr{nullptr};
@@ -98,6 +100,9 @@ std::string SwathGenerator::toString(const SwathType & type, const SwathAngleTyp
       break;
     case SwathType::COVERAGE:
       str = "Coverage";
+      break;
+    case SwathType::NUMBER_MODIFIED:
+      str = "Number Modified";
       break;
     default:
       str = "Unknown";
@@ -132,6 +137,8 @@ SwathType SwathGenerator::toType(const std::string & str)
     return SwathType::NUMBER;
   } else if (mode_str == "COVERAGE") {
     return SwathType::COVERAGE;
+  } else if (mode_str == "NUMBER_MODIFIED") {
+    return SwathType::NUMBER_MODIFIED;
   } else {
     return SwathType::UNKNOWN;
   }

--- a/opennav_coverage/test/test_swath.cpp
+++ b/opennav_coverage/test/test_swath.cpp
@@ -81,16 +81,23 @@ TEST(SwathTests, TestswathUtils)
   EXPECT_EQ(generator.toTypeShim("number"), SwathType::NUMBER);
   EXPECT_EQ(generator.toTypeShim("COVERAGE"), SwathType::COVERAGE);
   EXPECT_EQ(generator.toTypeShim("coverage"), SwathType::COVERAGE);
-
+  EXPECT_EQ(generator.toTypeShim("NUMBER_MODIFIED"), SwathType::NUMBER_MODIFIED);
+  EXPECT_EQ(generator.toTypeShim("number_modified"), SwathType::NUMBER_MODIFIED);
 
   EXPECT_EQ(generator.toStringShim(SwathType::NUMBER, SwathAngleType::SET_ANGLE).size(), 37u);
   EXPECT_EQ(generator.toStringShim(SwathType::COVERAGE, SwathAngleType::BRUTE_FORCE).size(), 41u);
   EXPECT_GT(generator.toStringShim(SwathType::UNKNOWN, SwathAngleType::UNKNOWN).size(), 20u);
   EXPECT_GT(generator.toStringShim(SwathType::UNKNOWN, SwathAngleType::BRUTE_FORCE).size(), 20u);
 
+  EXPECT_EQ(
+    generator.toStringShim(SwathType::NUMBER_MODIFIED, SwathAngleType::BRUTE_FORCE).size(), 48u);
+  EXPECT_EQ(
+    generator.toStringShim(SwathType::NUMBER_MODIFIED, SwathAngleType::SET_ANGLE).size(), 46u);
+
   EXPECT_TRUE(generator.createObjectiveShim(SwathType::LENGTH));
   EXPECT_TRUE(generator.createObjectiveShim(SwathType::NUMBER));
   EXPECT_TRUE(generator.createObjectiveShim(SwathType::COVERAGE));
+  EXPECT_TRUE(generator.createObjectiveShim(SwathType::NUMBER_MODIFIED));
   EXPECT_FALSE(generator.createObjectiveShim(SwathType::UNKNOWN));
 
   generator.setSwathAngleMode("NUMBER");
@@ -119,6 +126,9 @@ TEST(SwathTests, TestswathGeneration)
   settings.mode = "SET_ANGLE";
   settings.objective = "NUMBER";
   auto swaths3 = generator.generateSwaths(field.getField().getGeometry(0), settings);
+  settings.mode = "BRUTE_FORCE";
+  settings.objective = "NUMBER_MODIFIED";
+  auto swaths4 = generator.generateSwaths(field.getField().getGeometry(0), settings);
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <utility>
 
 #include "gtest/gtest.h"
@@ -201,6 +202,71 @@ TEST(UtilsTests, TestgetFieldFromGoal)
   goal->polygons[1].coordinates[0].axis1 = 1.0;
   auto field2 = util::getFieldFromGoal(goal);
   EXPECT_EQ(field2.getField().getGeometry(0).getGeometry(1).size(), 3u);
+}
+
+TEST(UtilsTests, TesttoNavPathMsgDiscreteSwathPointCount)
+{
+  // A single SWATH state with len=1.0 at step=0.1 → n_steps = round(1.0/0.1) = 10
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+  PathState s;
+  s.type = f2c::types::PathSectionType::SWATH;
+  s.point = Point(0.0, 0.0);
+  s.len = 1.0;
+  s.angle = 0.0;
+  path_in.addState(s);
+  F2CField field;
+
+  auto msg = util::toNavPathMsg(path_in, field, header_in, true, 0.1f);
+  EXPECT_EQ(msg.poses.size(), 10u);
+}
+
+TEST(UtilsTests, TesttoNavPathMsgTurnUnchanged)
+{
+  // TURN states must pass through discretizeSwath unmodified (regression guard)
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+  path_in.getStates().resize(10);
+  for (auto & state : path_in.getStates()) {
+    state.type = f2c::types::PathSectionType::TURN;
+  }
+  F2CField field;
+
+  auto msg = util::toNavPathMsg(path_in, field, header_in, true, 0.1f);
+  EXPECT_EQ(msg.poses.size(), 10u);
+}
+
+TEST(UtilsTests, TestGetTaskTime)
+{
+  Path path;
+  PathState s;
+  s.len = 5.0;
+  s.velocity = 2.0;
+  path.addState(s);
+
+  EXPECT_NEAR(path.getTaskTime(), 2.5, 0.01);
+}
+
+TEST(UtilsTests, TestGetTaskTimeZeroVelocity)
+{
+  // velocity=0 → getTaskTime() returns inf; caller must guard with std::isfinite
+  Path path;
+  PathState s;
+  s.len = 1.0;
+  s.velocity = 0.0;
+  path.addState(s);
+
+  EXPECT_FALSE(std::isfinite(path.getTaskTime()));
+  const double guarded = std::isfinite(path.getTaskTime()) ? path.getTaskTime() : 0.0;
+  EXPECT_NEAR(guarded, 0.0, 1e-9);
+}
+
+TEST(UtilsTests, TestGetTaskTimeEmptyPath)
+{
+  Path empty;
+  EXPECT_NEAR(empty.getTaskTime(), 0.0, 1e-9);
 }
 
 TEST(UtilsTests, TestPathComponentsIterator)

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -311,4 +311,119 @@ TEST(UtilsTests, TestPathComponentsIterator)
   EXPECT_EQ(std::get<1>(last_row_info), nullptr);
 }
 
+// B.6-T2: empty path → velocity and is_backward vectors are empty
+TEST(UtilsTests, TesttoNavPathMsgEmptyVelocity)
+{
+  std_msgs::msg::Header header_in;
+  Path empty_path;
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+
+  auto nav_path = util::toNavPathMsg(empty_path, field, header_in, true, 0.1f, vels, dirs);
+  EXPECT_TRUE(nav_path.poses.empty());
+  EXPECT_TRUE(vels.empty());
+  EXPECT_TRUE(dirs.empty());
+}
+
+// B.6-T3: forward-only path → all is_backward entries are false
+TEST(UtilsTests, TesttoNavPathMsgForwardOnly)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+  PathState s;
+  s.type = f2c::types::PathSectionType::SWATH;
+  s.point = Point(0.0, 0.0);
+  s.len = 1.0;
+  s.angle = 0.0;
+  s.velocity = 1.5;
+  s.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(s);
+  F2CField field;
+
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, vels, dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  for (const auto & d : dirs) {
+    EXPECT_FALSE(d);
+  }
+  for (const auto & v : vels) {
+    EXPECT_NEAR(v, 1.5, 1e-6);
+  }
+}
+
+// B.6-T1: velocity and is_backward values match PathState fields after discretizeSwath
+TEST(UtilsTests, TesttoNavPathMsgWithVelocity)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState swath;
+  swath.type = f2c::types::PathSectionType::SWATH;
+  swath.point = Point(0.0, 0.0);
+  swath.len = 1.0;
+  swath.angle = 0.0;
+  swath.velocity = 2.0;
+  swath.dir = f2c::types::PathDirection::BACKWARD;
+  path_in.addState(swath);
+
+  PathState turn;
+  turn.type = f2c::types::PathSectionType::TURN;
+  turn.velocity = 0.5;
+  turn.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(turn);
+
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, vels, dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  // SWATH states: velocity=2.0, direction=BACKWARD
+  EXPECT_NEAR(vels[0], 2.0, 1e-6);
+  EXPECT_TRUE(dirs[0]);
+  // TURN state: velocity=0.5, direction=FORWARD
+  EXPECT_NEAR(vels.back(), 0.5, 1e-6);
+  EXPECT_FALSE(dirs.back());
+}
+
+// B.6+B.7 integration: poses, velocities, is_backward sizes must match after discretizeSwath
+TEST(UtilsTests, TesttoNavPathMsgDensifyVelocitySizeMatch)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState swath;
+  swath.type = f2c::types::PathSectionType::SWATH;
+  swath.len = 1.0;
+  swath.velocity = 1.5;
+  swath.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(swath);
+
+  PathState turn;
+  turn.type = f2c::types::PathSectionType::TURN;
+  turn.velocity = 0.5;
+  turn.dir = f2c::types::PathDirection::BACKWARD;
+  path_in.addState(turn);
+  path_in.addState(turn);
+
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, vels, dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  // SWATH poses are forward; TURN poses are backward
+  EXPECT_FALSE(dirs[0]);
+  EXPECT_TRUE(dirs.back());
+}
+
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -320,7 +320,7 @@ TEST(UtilsTests, TesttoNavPathMsgEmptyVelocity)
   std::vector<double> vels;
   std::vector<bool> dirs;
 
-  auto nav_path = util::toNavPathMsg(empty_path, field, header_in, true, 0.1f, vels, dirs);
+  auto nav_path = util::toNavPathMsg(empty_path, field, header_in, true, 0.1f, &vels, &dirs);
   EXPECT_TRUE(nav_path.poses.empty());
   EXPECT_TRUE(vels.empty());
   EXPECT_TRUE(dirs.empty());
@@ -344,7 +344,7 @@ TEST(UtilsTests, TesttoNavPathMsgForwardOnly)
 
   std::vector<double> vels;
   std::vector<bool> dirs;
-  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, vels, dirs);
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
 
   EXPECT_EQ(nav_path.poses.size(), vels.size());
   EXPECT_EQ(nav_path.poses.size(), dirs.size());
@@ -381,7 +381,7 @@ TEST(UtilsTests, TesttoNavPathMsgWithVelocity)
   F2CField field;
   std::vector<double> vels;
   std::vector<bool> dirs;
-  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, vels, dirs);
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
 
   EXPECT_EQ(nav_path.poses.size(), vels.size());
   EXPECT_EQ(nav_path.poses.size(), dirs.size());
@@ -417,7 +417,7 @@ TEST(UtilsTests, TesttoNavPathMsgDensifyVelocitySizeMatch)
   F2CField field;
   std::vector<double> vels;
   std::vector<bool> dirs;
-  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, vels, dirs);
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
 
   EXPECT_EQ(nav_path.poses.size(), vels.size());
   EXPECT_EQ(nav_path.poses.size(), dirs.size());

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -35,6 +35,7 @@ uint16 INVALID_COORDS=803
 nav_msgs/Path nav_path
 opennav_coverage_msgs/PathComponents coverage_path
 builtin_interfaces/Duration planning_time
+float64 task_time
 uint16 error_code
 
 ---

--- a/opennav_coverage_msgs/msg/PathComponents.msg
+++ b/opennav_coverage_msgs/msg/PathComponents.msg
@@ -4,3 +4,8 @@ opennav_coverage_msgs/Swath[] swaths
 nav_msgs/Path[] turns
 bool contains_turns
 bool swaths_ordered
+
+# Per-pose velocity (m/s) and direction flags, parallel to nav_path.poses.
+# Populated only when generate_path=true. Empty when path is not generated.
+float64[] velocities
+bool[] is_backward

--- a/opennav_coverage_msgs/msg/SwathMode.msg
+++ b/opennav_coverage_msgs/msg/SwathMode.msg
@@ -1,4 +1,4 @@
-string objective "UNKNOWN"  # LENGTH, NUMBER, or COVERAGE
+string objective "UNKNOWN"  # LENGTH, NUMBER, NUMBER_MODIFIED, or COVERAGE
 string mode "UNKNOWN"  # BRUTE_FORCE, SET_ANGLE
 
 # Specific mode settings

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
+
 #include "opennav_row_coverage/row_coverage_server.hpp"
 
 using namespace std::chrono_literals;
@@ -207,6 +209,8 @@ void RowCoverageServer::computeCoveragePath()
           opennav_coverage::util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = opennav_coverage::util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance());
+        const double task_time = path.getTaskTime();
+        result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {
         result->coverage_path =
           opennav_coverage::util::toCoveragePathMsg(

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -207,8 +207,13 @@ void RowCoverageServer::computeCoveragePath()
 
         result->coverage_path =
           opennav_coverage::util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
+        std::vector<double> velocities;
+        std::vector<bool> is_backward;
         result->nav_path = opennav_coverage::util::toNavPathMsg(
-          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance());
+          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
+          velocities, is_backward);
+        result->coverage_path.velocities = velocities;
+        result->coverage_path.is_backward = is_backward;
         const double task_time = path.getTaskTime();
         result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -207,13 +207,9 @@ void RowCoverageServer::computeCoveragePath()
 
         result->coverage_path =
           opennav_coverage::util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
-        std::vector<double> velocities;
-        std::vector<bool> is_backward;
         result->nav_path = opennav_coverage::util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
-          velocities, is_backward);
-        result->coverage_path.velocities = velocities;
-        result->coverage_path.is_backward = is_backward;
+          result->coverage_path.velocities, result->coverage_path.is_backward);
         const double task_time = path.getTaskTime();
         result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -209,7 +209,7 @@ void RowCoverageServer::computeCoveragePath()
           opennav_coverage::util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = opennav_coverage::util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
-          result->coverage_path.velocities, result->coverage_path.is_backward);
+          &result->coverage_path.velocities, &result->coverage_path.is_backward);
         const double task_time = path.getTaskTime();
         result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {


### PR DESCRIPTION
## Summary

First of a few PRs splitting a larger Fields2Cover (F2C) v2 enhancement branch
into reviewable chunks, as discussed. It bundles three small, self-contained
output/objective improvements plus one build fix. None of these depend on the
larger field-decomposition / TSP-routing work that will follow in later PRs.

## Changes

**1. Per-pose velocity and direction on `PathComponents`**
- Adds `float64[] velocities` (m/s) and `bool[] is_backward` to
  `PathComponents.msg`, filled in parallel with `nav_path.poses`.
- New `toNavPathMsg` overload populates the per-pose velocity/direction vectors
  alongside the path; filled only when `generate_path=true`, empty otherwise.
- Wired through both `coverage_server` and `row_coverage_server`.

**2. Task time on the action result + `discretizeSwath` refactor**
- `toNavPathMsg` now uses `Path::discretizeSwath(step_size)` instead of a
  hand-written linear-interpolation loop — only `SWATH` states are split,
  `TURN` states pass through unchanged.
- Adds `float64 task_time` to the `ComputeCoveragePath` action result,
  populated from `Path::getTaskTime()` with an `std::isfinite` guard for
  zero-velocity states.

**3. `NUMBER_MODIFIED` swath objective**
- Exposes Fields2Cover's `f2c::obj::NSwathModified` as a selectable swath
  objective via `NUMBER_MODIFIED`, handled in
  `SwathGenerator::createObjective/toString/toType`.

**4. Build fix: keep `-Wnull-dereference` non-fatal**
- GCC false-positives on inlined ROS 2 message `operator==/!=` (e.g.
  `coordinate__struct.hpp`) reached via `getFieldFromGoal()`, breaking
  `-Werror` builds on newer toolchains. The warning stays visible but is no
  longer fatal.

## Interface changes (all additive)

- `PathComponents.msg`: `+ float64[] velocities`, `+ bool[] is_backward`
- `ComputeCoveragePath.action` (result): `+ float64 task_time`
- `SwathMode.msg`: `objective` now also accepts `NUMBER_MODIFIED` (doc comment updated)

## Testing

- `test_utils`: `discretizeSwath` point count, `TURN` passthrough regression,
  `getTaskTime` normal/zero/empty; plus empty-path, forward-only,
  velocity/direction values, and vector-size-match cases.
- `test_swath`: `NUMBER_MODIFIED` round-trips through
  `toType`/`toString`/`createObjective`, plus a generation smoke test.
