### PR TITLE
Add field decomposition (trapezoidal / boustrophedon) with HL_SWATH handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,8 @@ jobs:
     env:
       ROS_DISTRO: ${{ matrix.ros_distro }}
       RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
-      # Ubuntu 26.04 ships CMake 4.x, which hard-errors on dependencies that
-      # declare cmake_minimum_required(VERSION < 3.5) (e.g. the zlib bundled by
-      # ortools_vendor's OR-Tools). This lets CMake 4 accept those old minimums;
-      # it propagates into nested FetchContent/ExternalProject sub-builds too.
+      # CMake 4 (Ubuntu 26.04) rejects deps declaring cmake_minimum_required
+      # < 3.5 (e.g. OR-Tools' bundled zlib); accept them in sub-builds too.
       CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     container:
       image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-resolute-ros-rolling-ros-base:master
@@ -22,35 +20,19 @@ jobs:
       fail-fast: false
       matrix:
           ros_distro: [rolling]
-    # Rolling now targets Ubuntu 26.04 (resolute); the old ubuntu-noble-ros-rolling
-    # image is obsolete (rosdep no longer resolves rolling keys on noble). nav2
-    # (navigation2 main) and Fields2Cover are not released as binaries there, so
-    # they are built from source via deps.repos. We drive the build manually
-    # instead of action-ros-ci because nav2 main needs a source patch (-Werror)
-    # applied between vcs import and colcon build, which action-ros-ci disallows.
+    # Rolling targets Ubuntu 26.04 (resolute), which has no nav2 or Fields2Cover
+    # binaries: they are built from source via deps.repos, with source patches
+    # applied between import and build (which action-ros-ci disallows).
     steps:
     - uses: actions/checkout@v4
       with:
         path: ros_ws/src/opennav_coverage
 
     - name: Install system dependencies
-      # libompl-dev: nav2_smac_planner's find_package(ompl) -- the rosdep 'ompl'
-      #   key resolves to a ROS ompl whose API nav2 main doesn't match (see below).
-      # backward-ros: nav2 build dependency; install explicitly so a transient
-      #   rosdep gap can't fail the nav2 configure (seen in the rolling dev container).
-      # ament-cmake-vendor-package: build helper the *_vendor packages need on
-      #   rolling; a rosdep gap can leave it missing and fail their configure.
-      # libopenblas-dev: Fields2Cover builds matplot from source, which links
-      #   against OpenBLAS (-lopenblas). The resolute image no longer ships the
-      #   dev symlink, so provide /usr/lib/.../libopenblas.so or the link fails.
-      # message-filters: the resolute image's older message_filters lacks
-      #   systemClockNow(), which the newer point_cloud_transport it also ships
-      #   needs -- nav2_costmap_2d fails to link. Pull the current one to match.
-      # ament-index-cpp: behaviortree_cpp (built from master source) includes
-      #   ament_index_cpp/get_package_share_directory.hpp; a rosdep gap leaves the
-      #   header missing on the source build. Install it explicitly.
-      # The rest: Fields2Cover (gdal/eigen/geos/tinyxml2), tinyxml2-vendor for
-      #   opennav_row_coverage, Cyclone DDS, and vcstool/colcon.
+      # Deps rosdep can't (reliably) resolve on resolute: Fields2Cover build
+      # deps (gdal/eigen/geos/tinyxml2/OpenBLAS), system ompl 1.6 for nav2
+      # (the ROS ompl 2.x is dropped below), and image gap-fillers
+      # (backward-ros, vendor helper, message-filters, ament-index-cpp).
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
@@ -68,18 +50,13 @@ jobs:
       id: src_cache
       uses: actions/cache/restore@v4
       with:
-        # The vcs-imported third-party sources (nav2, Fields2Cover,
-        # ortools_vendor, behaviortree_cpp). Keyed on deps.repos, so the
-        # sources are frozen until the pins change; branch pins (nav2 main,
-        # BT.CPP master) do not drift underneath an existing cache. Restored
-        # with original mtimes so colcon can skip unchanged packages.
+        # Third-party sources, frozen until deps.repos changes; original
+        # mtimes let colcon skip them.
         path: ros_ws/src/deps
         key: srcdeps-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}
 
     - name: Import source dependencies
-      # Only on a cache miss. On a hit, src/deps is restored with its original
-      # mtimes so colcon skips the unchanged third-party packages; re-importing
-      # would reset those mtimes and force a full rebuild.
+      # Cache miss only: re-importing resets mtimes and forces a full rebuild.
       if: steps.src_cache.outputs.cache-hit != 'true'
       run: |
         cd ros_ws
@@ -87,27 +64,38 @@ jobs:
         vcs import src/deps < src/opennav_coverage/.github/deps.repos
 
     - name: Patch nav2_common (drop -Werror)
-      # nav2 main is not -Werror-clean under Ubuntu 26.04's GCC 15 (deprecated
-      # std::atomic_load on shared_ptr, null-dereference via builtin_interfaces,
-      # ...). nav2_common applies -Werror to every nav2 package, so strip it
-      # centrally. Our own opennav packages keep their own -Werror.
-      # Skipped on a cache hit: the cached sources are already patched, and
-      # sed -i would rewrite the file (new mtime) and trigger a nav2 rebuild.
+      # nav2 main is not -Werror-clean under GCC 15; strip it centrally.
+      # Cache miss only: cached sources are already patched.
       if: steps.src_cache.outputs.cache-hit != 'true'
       run: sed -i 's/ -Werror//' ros_ws/src/deps/navigation2/nav2_common/cmake/nav2_package.cmake
 
     - name: Patch nav2_map_server (missing rclcpp includes)
-      # nav2 main's map_io.cpp uses rclcpp::get_logger, RCLCPP_*_STREAM and
-      # rclcpp::Clock but includes no rclcpp header; the transitive includes
-      # it relied on are gone from current rolling's headers, so it fails to
-      # compile. Add the includes it actually uses. Skipped on a cache hit
-      # (cached sources are already patched; a new mtime would force a
-      # rebuild). Verified against the CI image locally: with this patch the
-      # full 54-package build succeeds.
+      # map_io.cpp uses rclcpp logging/Clock without including any rclcpp
+      # header; current rolling no longer provides them transitively.
       if: steps.src_cache.outputs.cache-hit != 'true'
       run: |
         sed -i 's|#include "nav2_map_server/map_io.hpp"|#include "rclcpp/clock.hpp"\n#include "rclcpp/logger.hpp"\n#include "rclcpp/logging.hpp"\n#include "nav2_map_server/map_io.hpp"|' \
           ros_ws/src/deps/navigation2/nav2_map_server/src/map_io.cpp
+
+    - name: Patch ortools_vendor (gurobi/math_opt proto race)
+      # OR-Tools v9.9: ortools_gurobi includes the generated math_opt
+      # gurobi.pb.h without depending on the target that generates it, racing
+      # the codegen under parallel make. Backport the one-line v9.10 fix via
+      # the vendor's patches/ dir.
+      if: steps.src_cache.outputs.cache-hit != 'true'
+      run: |
+        cat > ros_ws/src/deps/ortools_vendor/patches/0002-gurobi-mathopt-proto-dep.patch <<'EOF'
+        diff --git a/ortools/gurobi/CMakeLists.txt b/ortools/gurobi/CMakeLists.txt
+        --- a/ortools/gurobi/CMakeLists.txt
+        +++ b/ortools/gurobi/CMakeLists.txt
+        @@ -31,5 +31,6 @@
+           absl::str_format
+           protobuf::libprotobuf
+           ${PROJECT_NAMESPACE}::${PROJECT_NAME}_proto
+        +  ${PROJECT_NAMESPACE}::math_opt_proto
+           $<$<BOOL:${USE_COINOR}>:Coin::Cbc>)
+         #add_library(${PROJECT_NAMESPACE}::gurobi ALIAS ${NAME})
+        EOF
 
     - name: Install ROS dependencies (rosdep)
       run: |
@@ -116,33 +104,18 @@ jobs:
           --rosdistro ${{ matrix.ros_distro }} -r -y || true
 
     - name: Drop shadowing apt packages
-      # Both are resolved into the shared /opt/ros/<distro> tree (by the image or
-      # by rosdep) and shadow the version nav2 main is written against, so drop
-      # them here -- after rosdep -- and let find_package fall back to the right one.
-      #
-      # behaviortree_cpp: built from source (deps.repos: master) because nav2 main
-      #   uses its unreleased wakeUpSignal() API; the binary behaviortree_cpp (4.9.x)
-      #   headers would shadow the source-built master and break nav2_behavior_tree.
-      # ompl: rosdep resolves the 'ompl' key to the ROS ompl package (2.0.x), whose
-      #   ReedsShepp API differs (ReedsSheppStateSpace::ReedsSheppPath / reedsShepp()
-      #   were renamed/removed), so nav2 main's nav2_smac_planner fails to compile
-      #   against it. Removing it makes find_package(ompl) use the system
-      #   libompl-dev (1.6.x) installed above -- the API nav2 main expects.
+      # Both shadow what nav2 main is written against: binary behaviortree_cpp
+      # 4.9 lacks wakeUpSignal() (we build master from source); ROS ompl 2.x
+      # has a different ReedsShepp API than the system libompl-dev 1.6.
       run: |
         sudo apt-get remove -y ros-${{ matrix.ros_distro }}-behaviortree-cpp || true
         sudo apt-get remove -y ros-${{ matrix.ros_distro }}-ompl || true
 
     - name: Shim removed ament_index_cpp header
-      # ament_index_cpp 1.14 (rolling, 2026-06-30) removed
-      # get_package_share_directory() -- header and library symbol -- in favour
-      # of get_package_share_path(). Sources built from live branches still
-      # include it: BehaviorTree.CPP master (xml_parsing.cpp) and nav2 main
-      # (nav2_ros_common/node_utils.hpp includes it unconditionally; only the
-      # replacement include is version-guarded), plus several nav2 tests and
-      # opennav files. Restore the header as an inline forwarder until they
-      # migrate; skipped when the real header exists (older image, or upstream
-      # brings it back). The fixed mtime keeps cached objects that depend on
-      # it from being recompiled on every run.
+      # ament_index_cpp 1.14 removed get_package_share_directory() (header and
+      # symbol); BT.CPP master and nav2 main still include it. Forward to
+      # get_package_share_path() until they migrate. No-op when the real
+      # header exists; the fixed mtime keeps cached objects valid.
       run: |
         hdr=/opt/ros/${{ matrix.ros_distro }}/include/ament_index_cpp/ament_index_cpp/get_package_share_directory.hpp
         if [ ! -f "$hdr" ]; then
@@ -171,15 +144,10 @@ jobs:
         fi
 
     - name: Compute environment fingerprint
-      # Hash of every installed package version, taken after ALL apt/rosdep
-      # steps. It keys the colcon build cache to the exact environment the
-      # tree was built in. The container image tag (:master) is rebuilt
-      # nightly and rosdep installs from the live rolling repo, so /opt/ros
-      # changes underneath a cached build tree; reusing that tree in a
-      # different environment breaks incremental make in arbitrary ways
-      # (e.g. behaviortree_cpp recompiling xml_parsing.cpp with stale
-      # ament_index_cpp include paths). A changed fingerprint forces one
-      # clean rebuild instead.
+      # dpkg hash after all apt/rosdep steps. The :master image is rebuilt
+      # nightly; a build tree must only be reused in the environment it was
+      # configured in, so any drift forces one clean rebuild instead of a
+      # poisoned incremental one.
       id: env_fp
       run: |
         fp=$(dpkg-query -W -f '${Package} ${Version}\n' | sha256sum | cut -c1-16)
@@ -187,17 +155,9 @@ jobs:
 
     - name: Restore colcon cache
       id: colcon_cache
-      # The colcon build/ and install/ trees for the third-party sources;
-      # they take ~1h to build, caching makes repeat runs minutes. Keyed on
-      # deps.repos AND the environment fingerprint: a build tree is only ever
-      # reused in the environment it was configured in. No restore-keys on
-      # purpose -- a near-miss stale tree is worse than a clean rebuild.
-      # Skipped entirely if the source cache missed (e.g. evicted): an old
-      # build tree must never be combined with freshly imported sources.
-      # Our own opennav_coverage lives outside src/deps (checked out
-      # separately) and is always rebuilt against the cached deps. The
-      # container workspace path is stable across runs, so the absolute
-      # paths baked into install/ stay valid.
+      # Keyed on deps.repos + environment fingerprint; no restore-keys (a
+      # near-miss stale tree is worse than a clean rebuild). Skipped when the
+      # source cache missed so an old tree never meets fresh sources.
       if: steps.src_cache.outputs.cache-hit == 'true'
       uses: actions/cache/restore@v4
       with:
@@ -207,22 +167,23 @@ jobs:
         key: colcon-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}-${{ steps.env_fp.outputs.fp }}
 
     - name: Build
-      # slam_toolbox is only pulled in transitively as a runtime dep of
-      # nav2_bringup (via opennav_coverage_demo); nothing here builds against it,
-      # so skip it -- no reason to build it for these tests.
+      # slam_toolbox is only a runtime dep of nav2_bringup -- skip it.
+      # One visible retry: with ~50 from-source packages transient
+      # parallel-build flakes happen; a real error fails again in minutes.
       run: |
         cd ros_ws
         . /opt/ros/${{ matrix.ros_distro }}/setup.sh
-        colcon build --packages-up-to \
-          nav2_bt_navigator nav2_behavior_tree \
-          opennav_coverage opennav_coverage_bt opennav_coverage_demo \
-          opennav_coverage_msgs opennav_coverage_navigator opennav_row_coverage \
-          --packages-skip slam_toolbox
+        build() {
+          colcon build --packages-up-to \
+            nav2_bt_navigator nav2_behavior_tree \
+            opennav_coverage opennav_coverage_bt opennav_coverage_demo \
+            opennav_coverage_msgs opennav_coverage_navigator opennav_row_coverage \
+            --packages-skip slam_toolbox
+        }
+        build || { echo "::warning::colcon build failed once; retrying to rule out a transient parallel-build flake"; build; }
 
     - name: Save source dependencies cache
-      # Only after a successful build: if upstream (nav2 main / BT.CPP master)
-      # is broken at import time, the bad snapshot is not pinned and the next
-      # run imports fresh.
+      # Success only, so a broken upstream snapshot is never pinned.
       if: success() && steps.src_cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
@@ -230,11 +191,8 @@ jobs:
         key: ${{ steps.src_cache.outputs.cache-primary-key }}
 
     - name: Save colcon cache
-      # Save only after a successful build, and only when we didn't already have
-      # a hit -- so a broken or partial build (e.g. a raced ortools_vendor) is
-      # never cached. Runs before Test so a good build is preserved even if a
-      # test later fails. The key is spelled out (not cache-primary-key)
-      # because the restore step may have been skipped on a source-cache miss.
+      # Success only, before Test, so a good build survives a test failure.
+      # Key spelled out: the restore step may have been skipped.
       if: success() && steps.colcon_cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,19 @@ jobs:
       if: steps.src_cache.outputs.cache-hit != 'true'
       run: sed -i 's/ -Werror//' ros_ws/src/deps/navigation2/nav2_common/cmake/nav2_package.cmake
 
+    - name: Patch nav2_map_server (missing rclcpp includes)
+      # nav2 main's map_io.cpp uses rclcpp::get_logger, RCLCPP_*_STREAM and
+      # rclcpp::Clock but includes no rclcpp header; the transitive includes
+      # it relied on are gone from current rolling's headers, so it fails to
+      # compile. Add the includes it actually uses. Skipped on a cache hit
+      # (cached sources are already patched; a new mtime would force a
+      # rebuild). Verified against the CI image locally: with this patch the
+      # full 54-package build succeeds.
+      if: steps.src_cache.outputs.cache-hit != 'true'
+      run: |
+        sed -i 's|#include "nav2_map_server/map_io.hpp"|#include "rclcpp/clock.hpp"\n#include "rclcpp/logger.hpp"\n#include "rclcpp/logging.hpp"\n#include "nav2_map_server/map_io.hpp"|' \
+          ros_ws/src/deps/navigation2/nav2_map_server/src/map_io.cpp
+
     - name: Install ROS dependencies (rosdep)
       run: |
         rosdep update --rosdistro ${{ matrix.ros_distro }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,10 +81,12 @@ jobs:
       # OR-Tools v9.9: ortools_gurobi includes the generated math_opt
       # gurobi.pb.h without depending on the target that generates it, racing
       # the codegen under parallel make. Backport the one-line v9.10 fix via
-      # the vendor's patches/ dir.
-      if: steps.src_cache.outputs.cache-hit != 'true'
+      # the vendor's patches/ dir. Runs even on a source-cache hit (older
+      # caches predate this patch file); idempotent, fixed mtime.
       run: |
-        cat > ros_ws/src/deps/ortools_vendor/patches/0002-gurobi-mathopt-proto-dep.patch <<'EOF'
+        p=ros_ws/src/deps/ortools_vendor/patches/0002-gurobi-mathopt-proto-dep.patch
+        [ -f "$p" ] && exit 0
+        cat > "$p" <<'EOF'
         diff --git a/ortools/gurobi/CMakeLists.txt b/ortools/gurobi/CMakeLists.txt
         --- a/ortools/gurobi/CMakeLists.txt
         +++ b/ortools/gurobi/CMakeLists.txt
@@ -96,6 +98,7 @@ jobs:
            $<$<BOOL:${USE_COINOR}>:Coin::Cbc>)
          #add_library(${PROJECT_NAMESPACE}::gurobi ALIAS ${NAME})
         EOF
+        touch -d '2026-01-01 00:00:00 UTC' "$p"
 
     - name: Install ROS dependencies (rosdep)
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,9 @@ jobs:
       # message-filters: the resolute image's older message_filters lacks
       #   systemClockNow(), which the newer point_cloud_transport it also ships
       #   needs -- nav2_costmap_2d fails to link. Pull the current one to match.
+      # ament-index-cpp: behaviortree_cpp (built from master source) includes
+      #   ament_index_cpp/get_package_share_directory.hpp; a rosdep gap leaves the
+      #   header missing on the source build. Install it explicitly.
       # The rest: Fields2Cover (gdal/eigen/geos/tinyxml2), tinyxml2-vendor for
       #   opennav_row_coverage, Cyclone DDS, and vcstool/colcon.
       run: |
@@ -57,6 +60,7 @@ jobs:
           ros-${{ matrix.ros_distro }}-backward-ros \
           ros-${{ matrix.ros_distro }}-ament-cmake-vendor-package \
           ros-${{ matrix.ros_distro }}-message-filters \
+          ros-${{ matrix.ros_distro }}-ament-index-cpp \
           libgdal-dev libeigen3-dev libgeos-dev libtinyxml2-dev libompl-dev \
           libopenblas-dev
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,44 @@ jobs:
         sudo apt-get remove -y ros-${{ matrix.ros_distro }}-behaviortree-cpp || true
         sudo apt-get remove -y ros-${{ matrix.ros_distro }}-ompl || true
 
+    - name: Shim removed ament_index_cpp header
+      # ament_index_cpp 1.14 (rolling, 2026-06-30) removed
+      # get_package_share_directory() -- header and library symbol -- in favour
+      # of get_package_share_path(). Sources built from live branches still
+      # include it: BehaviorTree.CPP master (xml_parsing.cpp) and nav2 main
+      # (nav2_ros_common/node_utils.hpp includes it unconditionally; only the
+      # replacement include is version-guarded), plus several nav2 tests and
+      # opennav files. Restore the header as an inline forwarder until they
+      # migrate; skipped when the real header exists (older image, or upstream
+      # brings it back). The fixed mtime keeps cached objects that depend on
+      # it from being recompiled on every run.
+      run: |
+        hdr=/opt/ros/${{ matrix.ros_distro }}/include/ament_index_cpp/ament_index_cpp/get_package_share_directory.hpp
+        if [ ! -f "$hdr" ]; then
+          sudo tee "$hdr" > /dev/null <<'EOF'
+        // CI compat shim for ament_index_cpp >= 1.14, which removed this header.
+        #ifndef AMENT_INDEX_CPP__GET_PACKAGE_SHARE_DIRECTORY_HPP_
+        #define AMENT_INDEX_CPP__GET_PACKAGE_SHARE_DIRECTORY_HPP_
+
+        #include <string>
+
+        #include "ament_index_cpp/get_package_share_path.hpp"
+
+        namespace ament_index_cpp
+        {
+
+        inline std::string get_package_share_directory(const std::string & package_name)
+        {
+          return get_package_share_path(package_name).string();
+        }
+
+        }  // namespace ament_index_cpp
+
+        #endif  // AMENT_INDEX_CPP__GET_PACKAGE_SHARE_DIRECTORY_HPP_
+        EOF
+          sudo touch -d '2026-01-01 00:00:00 UTC' "$hdr"
+        fi
+
     - name: Compute environment fingerprint
       # Hash of every installed package version, taken after ALL apt/rosdep
       # steps. It keys the colcon build cache to the exact environment the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,31 +64,23 @@ jobs:
           libgdal-dev libeigen3-dev libgeos-dev libtinyxml2-dev libompl-dev \
           libopenblas-dev
 
-    - name: Restore colcon cache
-      id: colcon_cache
+    - name: Restore source dependencies cache
+      id: src_cache
       uses: actions/cache/restore@v4
       with:
         # The vcs-imported third-party sources (nav2, Fields2Cover,
-        # ortools_vendor, behaviortree_cpp) plus the colcon build/
-        # and install/ trees. These take ~1h to build from source; caching them
-        # means they build exactly once and are reused, so the ortools_vendor
-        # parallel-build race cannot recur and CI drops from ~60 min to minutes.
-        # Keyed on deps.repos, so any change to the third-party pins rebuilds all
-        # of them. Our own opennav_coverage lives outside src/deps (checked out
-        # separately) and is therefore always rebuilt against the cached deps.
-        # The container workspace path is stable across runs, so the absolute
-        # paths baked into install/ stay valid.
-        path: |
-          ros_ws/src/deps
-          ros_ws/build
-          ros_ws/install
-        key: colcon-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}
+        # ortools_vendor, behaviortree_cpp). Keyed on deps.repos, so the
+        # sources are frozen until the pins change; branch pins (nav2 main,
+        # BT.CPP master) do not drift underneath an existing cache. Restored
+        # with original mtimes so colcon can skip unchanged packages.
+        path: ros_ws/src/deps
+        key: srcdeps-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}
 
     - name: Import source dependencies
       # Only on a cache miss. On a hit, src/deps is restored with its original
       # mtimes so colcon skips the unchanged third-party packages; re-importing
       # would reset those mtimes and force a full rebuild.
-      if: steps.colcon_cache.outputs.cache-hit != 'true'
+      if: steps.src_cache.outputs.cache-hit != 'true'
       run: |
         cd ros_ws
         mkdir -p src/deps
@@ -101,7 +93,7 @@ jobs:
       # centrally. Our own opennav packages keep their own -Werror.
       # Skipped on a cache hit: the cached sources are already patched, and
       # sed -i would rewrite the file (new mtime) and trigger a nav2 rebuild.
-      if: steps.colcon_cache.outputs.cache-hit != 'true'
+      if: steps.src_cache.outputs.cache-hit != 'true'
       run: sed -i 's/ -Werror//' ros_ws/src/deps/navigation2/nav2_common/cmake/nav2_package.cmake
 
     - name: Install ROS dependencies (rosdep)
@@ -127,6 +119,42 @@ jobs:
         sudo apt-get remove -y ros-${{ matrix.ros_distro }}-behaviortree-cpp || true
         sudo apt-get remove -y ros-${{ matrix.ros_distro }}-ompl || true
 
+    - name: Compute environment fingerprint
+      # Hash of every installed package version, taken after ALL apt/rosdep
+      # steps. It keys the colcon build cache to the exact environment the
+      # tree was built in. The container image tag (:master) is rebuilt
+      # nightly and rosdep installs from the live rolling repo, so /opt/ros
+      # changes underneath a cached build tree; reusing that tree in a
+      # different environment breaks incremental make in arbitrary ways
+      # (e.g. behaviortree_cpp recompiling xml_parsing.cpp with stale
+      # ament_index_cpp include paths). A changed fingerprint forces one
+      # clean rebuild instead.
+      id: env_fp
+      run: |
+        fp=$(dpkg-query -W -f '${Package} ${Version}\n' | sha256sum | cut -c1-16)
+        echo "fp=${fp}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore colcon cache
+      id: colcon_cache
+      # The colcon build/ and install/ trees for the third-party sources;
+      # they take ~1h to build, caching makes repeat runs minutes. Keyed on
+      # deps.repos AND the environment fingerprint: a build tree is only ever
+      # reused in the environment it was configured in. No restore-keys on
+      # purpose -- a near-miss stale tree is worse than a clean rebuild.
+      # Skipped entirely if the source cache missed (e.g. evicted): an old
+      # build tree must never be combined with freshly imported sources.
+      # Our own opennav_coverage lives outside src/deps (checked out
+      # separately) and is always rebuilt against the cached deps. The
+      # container workspace path is stable across runs, so the absolute
+      # paths baked into install/ stay valid.
+      if: steps.src_cache.outputs.cache-hit == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ros_ws/build
+          ros_ws/install
+        key: colcon-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}-${{ steps.env_fp.outputs.fp }}
+
     - name: Build
       # slam_toolbox is only pulled in transitively as a runtime dep of
       # nav2_bringup (via opennav_coverage_demo); nothing here builds against it,
@@ -140,19 +168,29 @@ jobs:
           opennav_coverage_msgs opennav_coverage_navigator opennav_row_coverage \
           --packages-skip slam_toolbox
 
+    - name: Save source dependencies cache
+      # Only after a successful build: if upstream (nav2 main / BT.CPP master)
+      # is broken at import time, the bad snapshot is not pinned and the next
+      # run imports fresh.
+      if: success() && steps.src_cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ros_ws/src/deps
+        key: ${{ steps.src_cache.outputs.cache-primary-key }}
+
     - name: Save colcon cache
       # Save only after a successful build, and only when we didn't already have
       # a hit -- so a broken or partial build (e.g. a raced ortools_vendor) is
       # never cached. Runs before Test so a good build is preserved even if a
-      # test later fails.
+      # test later fails. The key is spelled out (not cache-primary-key)
+      # because the restore step may have been skipped on a source-cache miss.
       if: success() && steps.colcon_cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |
-          ros_ws/src/deps
           ros_ws/build
           ros_ws/install
-        key: ${{ steps.colcon_cache.outputs.cache-primary-key }}
+        key: colcon-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}-${{ steps.env_fp.outputs.fp }}
 
     - name: Test
       run: |

--- a/opennav_coverage/CMakeLists.txt
+++ b/opennav_coverage/CMakeLists.txt
@@ -69,6 +69,7 @@ set(dep_targets
 
 add_library(${library_name} SHARED
   src/coverage_server.cpp
+  src/decomp_generator.cpp
   src/headland_generator.cpp
   src/swath_generator.cpp
   src/route_generator.cpp

--- a/opennav_coverage/include/opennav_coverage/coverage_server.hpp
+++ b/opennav_coverage/include/opennav_coverage/coverage_server.hpp
@@ -24,6 +24,7 @@
 #include "nav2_ros_common/lifecycle_node.hpp"
 #include "nav2_ros_common/node_utils.hpp"
 #include "nav2_ros_common/simple_action_server.hpp"
+#include "opennav_coverage/decomp_generator.hpp"
 #include "opennav_coverage/headland_generator.hpp"
 #include "opennav_coverage/swath_generator.hpp"
 #include "opennav_coverage/route_generator.hpp"
@@ -123,12 +124,14 @@ protected:
   typename ActionServer::SharedPtr action_server_;
 
   std::unique_ptr<RobotParams> robot_params_;
+  std::unique_ptr<DecompGenerator> decomp_gen_;
   std::unique_ptr<HeadlandGenerator> headland_gen_;
   std::unique_ptr<SwathGenerator> swath_gen_;
   std::unique_ptr<RouteGenerator> route_gen_;
   std::unique_ptr<PathGenerator> path_gen_;
   std::unique_ptr<Visualizer> visualizer_;
   bool cartesian_frame_;
+  bool default_generate_decomp_{false};
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/include/opennav_coverage/decomp_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/decomp_generator.hpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENNAV_COVERAGE__DECOMP_GENERATOR_HPP_
+#define OPENNAV_COVERAGE__DECOMP_GENERATOR_HPP_
+
+#include <string>
+
+#include "fields2cover.h" // NOLINT
+
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_ros_common/lifecycle_node.hpp"
+#include "nav2_ros_common/node_utils.hpp"
+#include "opennav_coverage_msgs/msg/decomp_mode.hpp"
+#include "opennav_coverage/utils.hpp"
+#include "opennav_coverage/types.hpp"
+
+namespace opennav_coverage
+{
+
+/**
+ * @class Decomposition mode and state
+ */
+class DecompGenerator
+{
+public:
+  /**
+   * @brief Constructor for Decomposition mode
+   * @param node A node to get the Decomposition type from
+   */
+  template<typename NodeT>
+  explicit DecompGenerator(const NodeT & node)
+  {
+    logger_ = node->get_logger();
+
+    nav2::declare_parameter_if_not_declared(
+      node, "default_decomp_type", rclcpp::ParameterValue("NONE"));
+    std::string type_str = node->get_parameter("default_decomp_type").as_string();
+    default_type_ = toType(type_str);
+
+    nav2::declare_parameter_if_not_declared(
+      node, "default_decomp_split_angle", rclcpp::ParameterValue(0.0));
+    default_split_angle_ = node->get_parameter("default_decomp_split_angle").as_double();
+  }
+
+  /**
+   * @brief Main method to decompose a field into simpler sub-cells
+   * @param cells Cells to decompose
+   * @param settings Action request information
+   * @return Decomposed cells (may be a single cell if NONE)
+   */
+  F2CCells decompose(
+    const F2CCells & cells,
+    const opennav_coverage_msgs::msg::DecompMode & settings);
+
+  /**
+   * @brief Sets the mode manually of the Decomposition for dynamic parameters
+   * @param new_mode String for mode to use
+   */
+  void setMode(const std::string & new_mode);
+
+  /**
+   * @brief Sets the split angle manually for dynamic parameters
+   * @param angle Split angle in radians
+   */
+  void setSplitAngle(double angle) {default_split_angle_ = angle;}
+
+protected:
+  /**
+   * @brief Converts the Decomposition mode into a string for publication
+   * @param type Type of mode
+   * @return String of mode
+   */
+  std::string toString(const DecompType & type);
+
+  /**
+   * @brief Converts the Decomposition string into a mode for handling
+   * @param str String of mode
+   * @return Type of mode
+   */
+  DecompType toType(const std::string & str);
+
+  DecompType default_type_;
+  double default_split_angle_;
+  rclcpp::Logger logger_{rclcpp::get_logger("DecompGenerator")};
+};
+
+}  // namespace opennav_coverage
+
+#endif  // OPENNAV_COVERAGE__DECOMP_GENERATOR_HPP_

--- a/opennav_coverage/include/opennav_coverage/headland_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/headland_generator.hpp
@@ -65,6 +65,15 @@ public:
     const Field & field, const opennav_coverage_msgs::msg::HeadlandMode & settings);
 
   /**
+   * @brief Multi-cell overload: apply a separate headland to each sub-cell
+   * @param cells Cells to generate headlands from
+   * @param settings Action request information
+   * @return Cells with headlands applied per sub-cell
+   */
+  F2CCells generateHeadlands(
+    const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings);
+
+  /**
    * @brief Sets the mode manually of the Headland for dynamic parameters
    * @param mode String for mode to use
    */

--- a/opennav_coverage/include/opennav_coverage/swath_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/swath_generator.hpp
@@ -118,10 +118,10 @@ public:
   void setOVerlap(const bool & setting) {default_allow_overlap_ = setting;}
 
   /**
-   * @brief Sets default search step for brute force for dynamic parameters
-   * @param mode String for mode to use
+   * @brief Sets default search step angle for brute force for dynamic parameters
+   * @param setting Step angle in radians
    */
-  void setStepAngle(const bool & setting) {default_step_angle_ = setting;}
+  void setStepAngle(const double & setting) {default_step_angle_ = setting;}
 
 protected:
   /**

--- a/opennav_coverage/include/opennav_coverage/swath_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/swath_generator.hpp
@@ -85,6 +85,15 @@ public:
     const Field & field, const opennav_coverage_msgs::msg::SwathMode & settings);
 
   /**
+   * @brief Multi-cell overload: generate swaths across decomposed cells
+   * @param cells Cells to generate swaths from
+   * @param settings Action request information
+   * @return Flattened swaths across all cells
+   */
+  Swaths generateSwaths(
+    const F2CCells & cells, const opennav_coverage_msgs::msg::SwathMode & settings);
+
+  /**
    * @brief Sets the mode manually of the swath for dynamic parameters
    * @param mode String for mode to use
    */
@@ -115,6 +124,25 @@ public:
   void setStepAngle(const bool & setting) {default_step_angle_ = setting;}
 
 protected:
+  /**
+   * @struct Resolved swath parameters shared by the single- and multi-cell paths
+   */
+  struct ResolvedSwathParams
+  {
+    SwathObjectivePtr objective;
+    SwathAngleType angle_type;
+    float swath_angle;
+    float step_angle;
+  };
+
+  /**
+   * @brief Resolves action-vs-default swath parameters (shared logic)
+   * @param settings Action request information
+   * @return Resolved parameters
+   */
+  ResolvedSwathParams resolveSwathParams(
+    const opennav_coverage_msgs::msg::SwathMode & settings);
+
   /**
    * @brief Creates objective pointer of a requested type
    * @param type Swaths generator type to create

--- a/opennav_coverage/include/opennav_coverage/types.hpp
+++ b/opennav_coverage/include/opennav_coverage/types.hpp
@@ -107,6 +107,17 @@ enum class PathContinuityType
   DISCONTINUOUS = 2
 };
 
+/**
+ * @enum Decomposition types
+ */
+enum class DecompType
+{
+  UNKNOWN = 0,
+  NONE = 1,
+  TRAPEZOIDAL = 2,
+  BOUSTROPHEDON = 3
+};
+
 class CoverageException : public std::runtime_error
 {
 public:

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -142,8 +142,14 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
     path.moveTo(field.getRefPoint());
   }
 
+  // Decomposition produces HL_SWATH states for inter-cell headland passes;
+  // treat them like regular SWATH states.
+  auto isSwathLike = [](PathSectionType t) {
+      return t == PathSectionType::SWATH || t == PathSectionType::HL_SWATH;
+    };
+
   PathSectionType curr_state = path[0].type;
-  if (curr_state == PathSectionType::SWATH) {
+  if (isSwathLike(curr_state)) {
     curr_swath_start = path[0].point;
   } else if (curr_state == PathSectionType::TURN) {
     msg.turns.push_back(nav_msgs::msg::Path());
@@ -152,14 +158,19 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
   }
 
   for (unsigned int i = 0; i != path.size(); i++) {
-    if (curr_state == path[i].type && path[i].type == PathSectionType::SWATH) {
-      // Continuing swath so...
+    const bool prev_swath = isSwathLike(curr_state);
+    const bool prev_turn = curr_state == PathSectionType::TURN;
+    const bool now_swath = isSwathLike(path[i].type);
+    const bool now_turn = path[i].type == PathSectionType::TURN;
+
+    if (prev_swath && now_swath) {
+      // Continuing swath (SWATH or HL_SWATH) so...
       // (1) no action required.
-    } else if (curr_state == path[i].type && path[i].type == PathSectionType::TURN) {
+    } else if (prev_turn && now_turn) {
       // Continuing a turn so...
       // (1) keep populating
       curr_turn->poses.push_back(toMsg(path[i]));
-    } else if (curr_state != path[i].type && path[i].type == PathSectionType::TURN) {
+    } else if (prev_swath && now_turn) {
       // Transitioning from a swath to a turn so...
       // (1) Complete the existing swath
       opennav_coverage_msgs::msg::Swath swath;
@@ -171,7 +182,7 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
       msg.turns.back().header = header;
       curr_turn = &msg.turns.back();
       curr_turn->poses.push_back(toMsg(path[i]));
-    } else if (curr_state != path[i].type && path[i].type == PathSectionType::SWATH) {
+    } else if (prev_turn && now_swath) {
       // Transitioning from a turn to a swath so...
       // (1) Update new swath starting point
       curr_swath_start = path[i].point;
@@ -179,14 +190,14 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
 
     curr_state = path[i].type;
 
-    if (path[i].type != PathSectionType::SWATH &&
+    if (!isSwathLike(path[i].type) &&
       path[i].type != PathSectionType::TURN)
     {
       throw std::runtime_error("Unknown type of path state detected, cannot obtain path!");
     }
   }
 
-  if (curr_state == PathSectionType::SWATH) {
+  if (isSwathLike(curr_state)) {
     opennav_coverage_msgs::msg::Swath swath;
     swath.start = toMsg(curr_swath_start);
     swath.end = toMsg(path.back().point);

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -36,11 +36,16 @@ CoverageServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
   auto node = shared_from_this();
 
   robot_params_ = std::make_unique<RobotParams>(node);
+  decomp_gen_ = std::make_unique<DecompGenerator>(node);
   headland_gen_ = std::make_unique<HeadlandGenerator>(node);
   swath_gen_ = std::make_unique<SwathGenerator>(node, robot_params_.get());
   route_gen_ = std::make_unique<RouteGenerator>(node);
   path_gen_ = std::make_unique<PathGenerator>(node, robot_params_.get());
   visualizer_ = std::make_unique<Visualizer>();
+
+  nav2::declare_parameter_if_not_declared(
+    node, "default_generate_decomp", rclcpp::ParameterValue(false));
+  get_parameter("default_generate_decomp", default_generate_decomp_);
 
   // If in GPS coordinates, we must convert to a CRS to compute coverage
   // Then, reconvert back to GPS for the user.
@@ -101,6 +106,7 @@ CoverageServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   route_gen_.reset();
   swath_gen_.reset();
   headland_gen_.reset();
+  decomp_gen_.reset();
   robot_params_.reset();
   return nav2::CallbackReturn::SUCCESS;
 }
@@ -186,14 +192,32 @@ void CoverageServer::computeCoveragePath()
       "Generating coverage path in %s frame for zone with %zu outer nodes and %zu inner polygons.",
       frame_id.c_str(), field.getGeometry(0).size(), field.size() - 1);
 
-    // (1) Optional: Remove headland from polygon field
-    Field field_no_headland = field;
-    if (goal->generate_headland) {
-      field_no_headland = headland_gen_->generateHeadlands(field, goal->headland_mode);
-    }
+    // (1) Optional: decompose non-convex field, then remove headland, then generate swaths
+    const bool do_decomp = goal->generate_decomp || default_generate_decomp_;
 
-    // (2) Generate swaths to cover polygon field, including internal voids
-    Swaths swaths = swath_gen_->generateSwaths(field_no_headland, goal->swath_mode);
+    Field field_no_headland = field;  // kept for the non-decomp path + visualization
+    Swaths swaths;
+    if (do_decomp) {
+      F2CCells raw_cells;
+      raw_cells.addGeometry(field);
+      F2CCells decomposed = decomp_gen_->decompose(raw_cells, goal->decomp_mode);
+
+      // Apply a separate headland to each sub-cell (F2C tutorial order: decompose then headland)
+      F2CCells cells_no_headland = decomposed;
+      if (goal->generate_headland) {
+        cells_no_headland = headland_gen_->generateHeadlands(decomposed, goal->headland_mode);
+      }
+      swaths = swath_gen_->generateSwaths(cells_no_headland, goal->swath_mode);
+      // field_no_headland stays the outer boundary; decomposed cells aren't visualized separately.
+    } else {
+      // (1) Optional: Remove headland from polygon field
+      if (goal->generate_headland) {
+        field_no_headland = headland_gen_->generateHeadlands(field, goal->headland_mode);
+      }
+
+      // (2) Generate swaths to cover polygon field, including internal voids
+      swaths = swath_gen_->generateSwaths(field_no_headland, goal->swath_mode);
+    }
 
     // (3) Optional: Generate an ordered route through the unordered swaths
     std_msgs::msg::Header header;

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -208,7 +208,6 @@ void CoverageServer::computeCoveragePath()
         cells_no_headland = headland_gen_->generateHeadlands(decomposed, goal->headland_mode);
       }
       swaths = swath_gen_->generateSwaths(cells_no_headland, goal->swath_mode);
-      // field_no_headland stays the outer boundary; decomposed cells aren't visualized separately.
     } else {
       // (1) Optional: Remove headland from polygon field
       if (goal->generate_headland) {

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -195,7 +195,7 @@ void CoverageServer::computeCoveragePath()
     // (1) Optional: decompose non-convex field, then remove headland, then generate swaths
     const bool do_decomp = goal->generate_decomp || default_generate_decomp_;
 
-    Field field_no_headland = field;  // kept for the non-decomp path + visualization
+    Field field_no_headland = field;
     Swaths swaths;
     if (do_decomp) {
       F2CCells raw_cells;

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -202,7 +202,7 @@ void CoverageServer::computeCoveragePath()
       raw_cells.addGeometry(field);
       F2CCells decomposed = decomp_gen_->decompose(raw_cells, goal->decomp_mode);
 
-      // Apply a separate headland to each sub-cell (F2C tutorial order: decompose then headland)
+      // Apply a separate headland to each sub-cell
       F2CCells cells_no_headland = decomposed;
       if (goal->generate_headland) {
         cells_no_headland = headland_gen_->generateHeadlands(decomposed, goal->headland_mode);

--- a/opennav_coverage/src/decomp_generator.cpp
+++ b/opennav_coverage/src/decomp_generator.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+#include <string>
+
+#include "opennav_coverage/decomp_generator.hpp"
+
+namespace opennav_coverage
+{
+
+F2CCells DecompGenerator::decompose(
+  const F2CCells & cells,
+  const opennav_coverage_msgs::msg::DecompMode & settings)
+{
+  // "UNKNOWN" -> use default_type_ (same pattern as Headland/Swath generators)
+  DecompType type = toType(settings.mode);
+  if (type == DecompType::UNKNOWN) {
+    type = default_type_;
+  }
+
+  double split_angle =
+    std::abs(settings.split_angle) < 1e-9 ?
+    default_split_angle_ : settings.split_angle;
+
+  if (type == DecompType::NONE) {
+    return cells;  // no-op
+  }
+
+  RCLCPP_DEBUG(
+    logger_, "Decomposing field with type %s, split_angle=%.3f",
+    toString(type).c_str(), split_angle);
+
+  if (type == DecompType::TRAPEZOIDAL) {
+    f2c::decomp::TrapezoidalDecomp decomp;
+    decomp.setSplitAngle(split_angle);
+    return decomp.decompose(cells);
+  } else if (type == DecompType::BOUSTROPHEDON) {
+    f2c::decomp::BoustrophedonDecomp decomp;
+    decomp.setSplitAngle(split_angle);
+    return decomp.decompose(cells);
+  }
+
+  throw CoverageException("Unknown decomp type requested!");
+}
+
+std::string DecompGenerator::toString(const DecompType & type)
+{
+  switch (type) {
+    case DecompType::NONE: return "NONE";
+    case DecompType::TRAPEZOIDAL: return "TRAPEZOIDAL";
+    case DecompType::BOUSTROPHEDON: return "BOUSTROPHEDON";
+    default: return "UNKNOWN";
+  }
+}
+
+DecompType DecompGenerator::toType(const std::string & str)
+{
+  std::string upper = str;
+  util::toUpper(upper);
+  if (upper == "NONE") {
+    return DecompType::NONE;
+  }
+  if (upper == "TRAPEZOIDAL") {
+    return DecompType::TRAPEZOIDAL;
+  }
+  if (upper == "BOUSTROPHEDON") {
+    return DecompType::BOUSTROPHEDON;
+  }
+  return DecompType::UNKNOWN;  // left to caller (falls back to default)
+}
+
+void DecompGenerator::setMode(const std::string & new_mode)
+{
+  default_type_ = toType(new_mode);
+}
+
+}  // namespace opennav_coverage

--- a/opennav_coverage/src/headland_generator.cpp
+++ b/opennav_coverage/src/headland_generator.cpp
@@ -46,6 +46,16 @@ Field HeadlandGenerator::generateHeadlands(
   return generator->generateHeadlands(Fields(field), width).getGeometry(0);
 }
 
+F2CCells HeadlandGenerator::generateHeadlands(
+  const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings)
+{
+  F2CCells result;
+  for (size_t i = 0; i < cells.size(); ++i) {
+    result.addGeometry(generateHeadlands(cells.getGeometry(i), settings));
+  }
+  return result;
+}
+
 void HeadlandGenerator::setMode(const std::string & new_mode)
 {
   default_type_ = toType(new_mode);

--- a/opennav_coverage/src/swath_generator.cpp
+++ b/opennav_coverage/src/swath_generator.cpp
@@ -55,7 +55,8 @@ Swaths SwathGenerator::generateSwaths(
   switch (p.angle_type) {
     case SwathAngleType::BRUTE_FORCE:
       if (!p.objective) {
-        throw CoverageException("No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE.");
+        throw CoverageException(
+                "No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE, NUMBER_MODIFIED.");
       }
       generator_->setStepAngle(p.step_angle);
       return generator_->generateBestSwaths(*p.objective, op_width, field);
@@ -80,7 +81,8 @@ Swaths SwathGenerator::generateSwaths(
   switch (p.angle_type) {
     case SwathAngleType::BRUTE_FORCE:
       if (!p.objective) {
-        throw CoverageException("No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE.");
+        throw CoverageException(
+                "No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE, NUMBER_MODIFIED.");
       }
       generator_->setStepAngle(p.step_angle);
       return generator_->generateBestSwaths(*p.objective, op_width, cells).flatten();

--- a/opennav_coverage/src/swath_generator.cpp
+++ b/opennav_coverage/src/swath_generator.cpp
@@ -20,41 +20,72 @@
 namespace opennav_coverage
 {
 
-Swaths SwathGenerator::generateSwaths(
-  const Field & field, const opennav_coverage_msgs::msg::SwathMode & settings)
+SwathGenerator::ResolvedSwathParams SwathGenerator::resolveSwathParams(
+  const opennav_coverage_msgs::msg::SwathMode & settings)
 {
   SwathType action_type = toType(settings.objective);
   SwathAngleType action_angle_type = toAngleType(settings.mode);
-  SwathObjectivePtr objective{nullptr};
-  float swath_angle = 0.0f;
-  float step_angle = 0.0f;
+  ResolvedSwathParams p;
 
   // If not set by action, use default mode
   if (action_type == SwathType::UNKNOWN && action_angle_type == SwathAngleType::UNKNOWN) {
     action_type = default_type_;
-    action_angle_type = default_angle_type_;
-    objective = default_objective_;
-    swath_angle = default_swath_angle_;
-    step_angle = default_step_angle_;
+    p.angle_type = default_angle_type_;
+    p.objective = default_objective_;
+    p.swath_angle = default_swath_angle_;
+    p.step_angle = default_step_angle_;
   } else {
-    objective = createObjective(action_type);
-    swath_angle = settings.best_angle;
-    step_angle = settings.step_angle;
+    p.angle_type = action_angle_type;
+    p.objective = createObjective(action_type);
+    p.swath_angle = settings.best_angle;
+    p.step_angle = settings.step_angle;
   }
 
   RCLCPP_DEBUG(
-    logger_, "Generating Swaths with: %s", toString(action_type, action_angle_type).c_str());
+    logger_, "Generating Swaths with: %s", toString(action_type, p.angle_type).c_str());
+  return p;
+}
 
+Swaths SwathGenerator::generateSwaths(
+  const Field & field, const opennav_coverage_msgs::msg::SwathMode & settings)
+{
+  ResolvedSwathParams p = resolveSwathParams(settings);
+  const double op_width = robot_params_->getOperationWidth();
   generator_->setAllowOverlap(default_allow_overlap_);
-  switch (action_angle_type) {
+  switch (p.angle_type) {
     case SwathAngleType::BRUTE_FORCE:
-      if (!objective) {
+      if (!p.objective) {
         throw CoverageException("No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE.");
       }
-      generator_->setStepAngle(step_angle);
-      return generator_->generateBestSwaths(*objective, robot_params_->getOperationWidth(), field);
+      generator_->setStepAngle(p.step_angle);
+      return generator_->generateBestSwaths(*p.objective, op_width, field);
     case SwathAngleType::SET_ANGLE:
-      return generator_->generateSwaths(swath_angle, robot_params_->getOperationWidth(), field);
+      return generator_->generateSwaths(p.swath_angle, op_width, field);
+    default:
+      throw CoverageException("No valid swath angle mode set! Options: BRUTE_FORCE, SET_ANGLE.");
+  }
+}
+
+Swaths SwathGenerator::generateSwaths(
+  const F2CCells & cells, const opennav_coverage_msgs::msg::SwathMode & settings)
+{
+  // Single cell -> use the existing Field path (no flatten needed)
+  if (cells.size() == 1) {
+    return generateSwaths(cells.getGeometry(0), settings);
+  }
+
+  ResolvedSwathParams p = resolveSwathParams(settings);
+  const double op_width = robot_params_->getOperationWidth();
+  generator_->setAllowOverlap(default_allow_overlap_);
+  switch (p.angle_type) {
+    case SwathAngleType::BRUTE_FORCE:
+      if (!p.objective) {
+        throw CoverageException("No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE.");
+      }
+      generator_->setStepAngle(p.step_angle);
+      return generator_->generateBestSwaths(*p.objective, op_width, cells).flatten();
+    case SwathAngleType::SET_ANGLE:
+      return generator_->generateSwaths(p.swath_angle, op_width, cells).flatten();
     default:
       throw CoverageException("No valid swath angle mode set! Options: BRUTE_FORCE, SET_ANGLE.");
   }

--- a/opennav_coverage/test/CMakeLists.txt
+++ b/opennav_coverage/test/CMakeLists.txt
@@ -22,6 +22,14 @@ target_link_libraries(test_viz
   ${library_name}
 )
 
+# Test decomp
+ament_add_gtest(test_decomp_generator
+  test_decomp_generator.cpp
+)
+target_link_libraries(test_decomp_generator
+  ${library_name}
+)
+
 # Test headland
 ament_add_gtest(test_headland
   test_headland.cpp

--- a/opennav_coverage/test/test_decomp_generator.cpp
+++ b/opennav_coverage/test/test_decomp_generator.cpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "opennav_coverage/decomp_generator.hpp"
+#include "opennav_coverage_msgs/msg/decomp_mode.hpp"
+#include "fields2cover/utils/random.h"
+
+// Luckily, F2C has very high test coverage so we only need to test what we touch
+
+class RosLockGuard
+{
+public:
+  RosLockGuard() {rclcpp::init(0, nullptr);}
+  ~RosLockGuard() {rclcpp::shutdown();}
+};
+RosLockGuard g_rclcpp;
+
+namespace opennav_coverage
+{
+
+using opennav_coverage_msgs::msg::DecompMode;
+
+class DecompShim : public DecompGenerator
+{
+public:
+  template<typename NodeT>
+  explicit DecompShim(const NodeT & node)
+  : DecompGenerator(node)
+  {}
+
+  std::string toStringShim(const DecompType & type)
+  {
+    return toString(type);
+  }
+
+  DecompType toTypeShim(const std::string & str)
+  {
+    return toType(str);
+  }
+};
+
+TEST(DecompTests, TestDecompUtils)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto gen = DecompShim(node);
+
+  // toType: unknown -> UNKNOWN (not a throw)
+  EXPECT_EQ(gen.toTypeShim("FAKE"), DecompType::UNKNOWN);
+  EXPECT_EQ(gen.toTypeShim("UNKNOWN"), DecompType::UNKNOWN);
+
+  // toType: case-insensitivity
+  EXPECT_EQ(gen.toTypeShim("NONE"), DecompType::NONE);
+  EXPECT_EQ(gen.toTypeShim("none"), DecompType::NONE);
+  EXPECT_EQ(gen.toTypeShim("TRAPEZOIDAL"), DecompType::TRAPEZOIDAL);
+  EXPECT_EQ(gen.toTypeShim("trapezoidal"), DecompType::TRAPEZOIDAL);
+  EXPECT_EQ(gen.toTypeShim("BOUSTROPHEDON"), DecompType::BOUSTROPHEDON);
+  EXPECT_EQ(gen.toTypeShim("boustrophedon"), DecompType::BOUSTROPHEDON);
+
+  // toString
+  EXPECT_EQ(gen.toStringShim(DecompType::NONE), std::string("NONE"));
+  EXPECT_EQ(gen.toStringShim(DecompType::TRAPEZOIDAL), std::string("TRAPEZOIDAL"));
+  EXPECT_EQ(gen.toStringShim(DecompType::BOUSTROPHEDON), std::string("BOUSTROPHEDON"));
+  EXPECT_GT(gen.toStringShim(DecompType::UNKNOWN).size(), 0u);
+
+  // setters should not throw
+  gen.setMode("TRAPEZOIDAL");
+  gen.setMode("none");
+  gen.setSplitAngle(0.5 * M_PI);
+}
+
+TEST(DecompTests, TestDecompNone)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto gen = DecompShim(node);
+  f2c::Random rand;
+  auto field = rand.generateRandField(1e5, 5);
+  F2CCells cells;
+  cells.addGeometry(field.getField().getGeometry(0));
+
+  DecompMode mode;
+  mode.mode = "NONE";
+  F2CCells result = gen.decompose(cells, mode);
+  EXPECT_EQ(result.size(), 1u);
+}
+
+TEST(DecompTests, TestDecompNonConvex)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto gen = DecompShim(node);
+
+  // Build an L-shaped non-convex polygon by hand
+  F2CLinearRing ring;
+  ring.addPoint(0, 0);
+  ring.addPoint(10, 0);
+  ring.addPoint(10, 5);
+  ring.addPoint(5, 5);
+  ring.addPoint(5, 10);
+  ring.addPoint(0, 10);
+  ring.addPoint(0, 0);  // closed ring
+  F2CCell cell;
+  cell.addRing(ring);
+  F2CCells cells;
+  cells.addGeometry(cell);
+
+  DecompMode mode;
+  mode.mode = "TRAPEZOIDAL";
+  F2CCells result_trap = gen.decompose(cells, mode);
+  EXPECT_GT(result_trap.size(), 1u);  // L-field must split
+
+  // BOUSTROPHEDON extends TrapezoidalDecomp with a merge step, so its exact cell
+  // count is F2C-internal (may merge back to one). Only verify it produces valid,
+  // non-empty output without throwing.
+  mode.mode = "BOUSTROPHEDON";
+  F2CCells result_bou = gen.decompose(cells, mode);
+  EXPECT_GE(result_bou.size(), 1u);
+}
+
+TEST(DecompTests, TestDecompDefaultFallback)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto gen = DecompShim(node);
+  f2c::Random rand;
+  auto field = rand.generateRandField(1e5, 5);
+  F2CCells cells;
+  cells.addGeometry(field.getField().getGeometry(0));
+
+  DecompMode mode;  // default mode = "UNKNOWN" -> default_type_ = NONE
+  F2CCells result = gen.decompose(cells, mode);
+  EXPECT_EQ(result.size(), cells.size());  // behaves like NONE, unchanged
+}
+
+}  // namespace opennav_coverage

--- a/opennav_coverage/test/test_headland.cpp
+++ b/opennav_coverage/test/test_headland.cpp
@@ -89,4 +89,28 @@ TEST(HeadlandTests, TestheadlandGeneration)
   auto field_out2 = generator.generateHeadlands(field.getField().getGeometry(0), settings);
 }
 
+TEST(HeadlandTests, TestheadlandGenerationMultiCell)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto generator = HeadlandShim(node);
+
+  f2c::Random rand;
+  auto field = rand.generateRandField(1e5, 5);
+  Field cell = field.getField().getGeometry(0);
+  double area_in = cell.area();
+
+  // 2-cell F2CCells
+  F2CCells cells;
+  cells.addGeometry(cell);
+  cells.addGeometry(cell);
+
+  opennav_coverage_msgs::msg::HeadlandMode settings;
+  F2CCells result = generator.generateHeadlands(cells, settings);
+
+  EXPECT_EQ(result.size(), 2u);
+  // Each cell should have shrunk (headland removed)
+  EXPECT_LT(result.getGeometry(0).area(), area_in);
+  EXPECT_LT(result.getGeometry(1).area(), area_in);
+}
+
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_server.cpp
+++ b/opennav_coverage/test/test_server.cpp
@@ -126,6 +126,94 @@ TEST(ServerTest, testServerTransactions)
   EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
 }
 
+TEST(ServerTest, testDecompPath)
+{
+  // Create server
+  auto node = std::make_shared<ServerShim>();
+  rclcpp_lifecycle::State state;
+  node->configure(state);
+  node->activate(state);
+  auto node_thread = std::make_unique<nav2::NodeThread>(node);
+
+  auto client_node = std::make_shared<rclcpp::Node>("my_node_decomp");
+  auto action_client =
+    rclcpp_action::create_client<opennav_coverage_msgs::action::ComputeCoveragePath>(
+    client_node, "compute_coverage_path");
+  action_client->wait_for_action_server();
+
+  auto goal_msg = opennav_coverage_msgs::action::ComputeCoveragePath::Goal();
+  goal_msg.use_gml_file = true;
+  goal_msg.generate_decomp = true;
+  goal_msg.decomp_mode.mode = "TRAPEZOIDAL";
+  goal_msg.generate_headland = true;
+  goal_msg.generate_route = true;
+  goal_msg.generate_path = true;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::filesystem::path share_dir =
+    ament_index_cpp::get_package_share_directory("opennav_coverage");
+#pragma GCC diagnostic pop
+  goal_msg.gml_field = (share_dir / "test_field.xml").string();
+
+  auto future_goal_handle = action_client->async_send_goal(goal_msg);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_goal_handle),
+    rclcpp::FutureReturnCode::SUCCESS);
+  auto goal_handle = future_goal_handle.get();
+
+  auto future_result = action_client->async_get_result(goal_handle);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_result),
+    rclcpp::FutureReturnCode::SUCCESS);
+
+  auto result = future_result.get();
+  EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
+}
+
+TEST(ServerTest, testDecompPathNoHeadland)
+{
+  // generate_headland=false exercises the cells_no_headland = decomposed branch
+  auto node = std::make_shared<ServerShim>();
+  rclcpp_lifecycle::State state;
+  node->configure(state);
+  node->activate(state);
+  auto node_thread = std::make_unique<nav2::NodeThread>(node);
+
+  auto client_node = std::make_shared<rclcpp::Node>("my_node_decomp_nohl");
+  auto action_client =
+    rclcpp_action::create_client<opennav_coverage_msgs::action::ComputeCoveragePath>(
+    client_node, "compute_coverage_path");
+  action_client->wait_for_action_server();
+
+  auto goal_msg = opennav_coverage_msgs::action::ComputeCoveragePath::Goal();
+  goal_msg.use_gml_file = true;
+  goal_msg.generate_decomp = true;
+  goal_msg.decomp_mode.mode = "BOUSTROPHEDON";
+  goal_msg.generate_headland = false;
+  goal_msg.generate_route = false;
+  goal_msg.generate_path = false;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::filesystem::path share_dir =
+    ament_index_cpp::get_package_share_directory("opennav_coverage");
+#pragma GCC diagnostic pop
+  goal_msg.gml_field = (share_dir / "test_field.xml").string();
+
+  auto future_goal_handle = action_client->async_send_goal(goal_msg);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_goal_handle),
+    rclcpp::FutureReturnCode::SUCCESS);
+  auto goal_handle = future_goal_handle.get();
+
+  auto future_result = action_client->async_get_result(goal_handle);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_result),
+    rclcpp::FutureReturnCode::SUCCESS);
+
+  auto result = future_result.get();
+  EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
+}
+
 TEST(ServerTest, testDynamicParams)
 {
   auto node = std::make_shared<ServerShim>();

--- a/opennav_coverage/test/test_swath.cpp
+++ b/opennav_coverage/test/test_swath.cpp
@@ -104,7 +104,7 @@ TEST(SwathTests, TestswathUtils)
   generator.setSwathMode("SET_ANGLE");
   generator.setSwathAngle(0.0);
   generator.setOVerlap(false);
-  generator.setStepAngle(false);
+  generator.setStepAngle(0.0);
 }
 
 TEST(SwathTests, TestswathGeneration)

--- a/opennav_coverage/test/test_swath.cpp
+++ b/opennav_coverage/test/test_swath.cpp
@@ -131,4 +131,30 @@ TEST(SwathTests, TestswathGeneration)
   auto swaths4 = generator.generateSwaths(field.getField().getGeometry(0), settings);
 }
 
+TEST(SwathTests, TestswathGenerationMultiCell)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot(node);
+  auto generator = SwathShim(node, &robot);
+
+  f2c::Random rand;
+  auto field = rand.generateRandField(1e5, 5);
+  Field cell = field.getField().getGeometry(0);
+
+  opennav_coverage_msgs::msg::SwathMode settings;
+
+  // Single-cell F2CCells routes through the Field path
+  F2CCells one_cell;
+  one_cell.addGeometry(cell);
+  auto swaths_one = generator.generateSwaths(one_cell, settings);
+  EXPECT_GT(swaths_one.size(), 0u);
+
+  // Multi-cell F2CCells flattens swaths across cells
+  F2CCells cells;
+  cells.addGeometry(cell);
+  cells.addGeometry(cell);
+  auto swaths_multi = generator.generateSwaths(cells, settings);
+  EXPECT_GT(swaths_multi.size(), swaths_one.size());
+}
+
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -132,10 +132,10 @@ TEST(UtilsTests, TesttoCoveragePathMsg2)
   EXPECT_EQ(msg.contains_turns, true);
   EXPECT_EQ(msg.swaths_ordered, true);
 
-  // states are not valid (e.g. non-marked as turn or swath). v2 defaults type to
-  // SWATH, so explicitly set an unhandled type (HL_SWATH) to trigger the error.
+  // states are not valid (e.g. non-marked as turn or swath). SWATH/TURN/HL_SWATH
+  // are all handled now, so cast an out-of-range value to trigger the error.
   path_in.getStates().resize(10);
-  path_in.getStates()[0].type = f2c::types::PathSectionType::HL_SWATH;
+  path_in.getStates()[0].type = static_cast<f2c::types::PathSectionType>(99);
   EXPECT_THROW(util::toCoveragePathMsg(path_in, field, header_in, true), std::runtime_error);
 
   // Now lets make it valid
@@ -171,6 +171,78 @@ TEST(UtilsTests, TesttoCoveragePathMsg2)
   EXPECT_EQ(msg.swaths.size(), 2u);
   EXPECT_EQ(msg.turns.size(), 3u);
   EXPECT_EQ(msg.turns[0].poses.size(), 2u);
+}
+
+// HL_SWATH states (produced by decomposition) must be handled like SWATH.
+TEST(UtilsTests, TesttoCoveragePathMsgHLSwath)
+{
+  using f2c::types::PathSectionType;
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  F2CField field;
+
+  // Scenario 1: only HL_SWATH -> one swath, no turns
+  {
+    Path path_in;
+    path_in.getStates().resize(3);
+    path_in.getStates()[0].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[1].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[2].type = PathSectionType::HL_SWATH;
+
+    auto msg = util::toCoveragePathMsg(path_in, field, header_in, true);
+    EXPECT_EQ(msg.swaths.size(), 1u);
+    EXPECT_EQ(msg.turns.size(), 0u);
+    EXPECT_EQ(msg.contains_turns, true);
+    EXPECT_EQ(msg.swaths_ordered, true);
+  }
+
+  // Scenario 2: HL_SWATH -> TURN -> SWATH (realistic decomposition output)
+  {
+    Path path_in;
+    path_in.getStates().resize(6);
+    path_in.getStates()[0].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[1].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[2].type = PathSectionType::TURN;
+    path_in.getStates()[3].type = PathSectionType::TURN;
+    path_in.getStates()[4].type = PathSectionType::SWATH;
+    path_in.getStates()[5].type = PathSectionType::SWATH;
+
+    auto msg = util::toCoveragePathMsg(path_in, field, header_in, true);
+    EXPECT_EQ(msg.swaths.size(), 2u);
+    EXPECT_EQ(msg.turns.size(), 1u);
+    EXPECT_EQ(msg.turns[0].poses.size(), 2u);
+  }
+
+  // Scenario 3: SWATH + HL_SWATH mixed (both in the swath-like group)
+  {
+    Path path_in;
+    path_in.getStates().resize(7);
+    path_in.getStates()[0].type = PathSectionType::SWATH;
+    path_in.getStates()[1].type = PathSectionType::SWATH;
+    path_in.getStates()[2].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[3].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[4].type = PathSectionType::TURN;
+    path_in.getStates()[5].type = PathSectionType::TURN;
+    path_in.getStates()[6].type = PathSectionType::SWATH;
+
+    auto msg = util::toCoveragePathMsg(path_in, field, header_in, true);
+    EXPECT_EQ(msg.swaths.size(), 2u);  // SWATH->HL_SWATH is a no-op (same swath block)
+    EXPECT_EQ(msg.turns.size(), 1u);
+  }
+
+  // Scenario 4: start with TURN, then transition to HL_SWATH (TURN -> swath-like edge)
+  {
+    Path path_in;
+    path_in.getStates().resize(4);
+    path_in.getStates()[0].type = PathSectionType::TURN;
+    path_in.getStates()[1].type = PathSectionType::TURN;
+    path_in.getStates()[2].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[3].type = PathSectionType::HL_SWATH;
+
+    auto msg = util::toCoveragePathMsg(path_in, field, header_in, true);
+    EXPECT_EQ(msg.turns.size(), 1u);
+    EXPECT_EQ(msg.swaths.size(), 1u);
+  }
 }
 
 TEST(UtilsTests, TestgetFieldFromGoal)
@@ -391,6 +463,44 @@ TEST(UtilsTests, TesttoNavPathMsgWithVelocity)
   // TURN state: velocity=0.5, direction=FORWARD
   EXPECT_NEAR(vels.back(), 0.5, 1e-6);
   EXPECT_FALSE(dirs.back());
+}
+
+// HL_SWATH states must carry velocity/direction through toNavPathMsg like SWATH does.
+TEST(UtilsTests, TesttoNavPathMsgHLSwathVelocity)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState hl_swath;
+  hl_swath.type = f2c::types::PathSectionType::HL_SWATH;
+  hl_swath.point = Point(0.0, 0.0);
+  hl_swath.len = 1.0;
+  hl_swath.angle = 0.0;
+  hl_swath.velocity = 1.5;
+  hl_swath.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(hl_swath);
+
+  PathState turn;
+  turn.type = f2c::types::PathSectionType::TURN;
+  turn.velocity = 0.5;
+  turn.dir = f2c::types::PathDirection::BACKWARD;
+  path_in.addState(turn);
+
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  // HL_SWATH state: velocity=1.5, direction=FORWARD, passes through as one point
+  // (discretizeSwath does not densify HL_SWATH, only SWATH)
+  EXPECT_NEAR(vels[0], 1.5, 1e-6);
+  EXPECT_FALSE(dirs[0]);
+  // TURN state: velocity=0.5, direction=BACKWARD
+  EXPECT_NEAR(vels.back(), 0.5, 1e-6);
+  EXPECT_TRUE(dirs.back());
 }
 
 // B.6+B.7 integration: poses, velocities, is_backward sizes must match after discretizeSwath

--- a/opennav_coverage_bt/include/opennav_coverage_bt/compute_complete_coverage_path.hpp
+++ b/opennav_coverage_bt/include/opennav_coverage_bt/compute_complete_coverage_path.hpp
@@ -89,6 +89,10 @@ public:
   {
     return providedBasicPorts(
       {
+        BT::InputPort<bool>("generate_decomp", false, "Whether to decompose non-convex field"),
+        BT::InputPort<std::string>(
+          "decomp_mode_type", "UNKNOWN", "NONE/TRAPEZOIDAL/BOUSTROPHEDON"),
+        BT::InputPort<double>("decomp_split_angle", 0.0, "Split angle in radians"),
         BT::InputPort<bool>("generate_headland", true, "Whether to generate headland"),
         BT::InputPort<bool>("generate_route", true, "Whether to ordered route of swaths"),
         BT::InputPort<bool>("generate_path", true, "Whether to generate connected path of routes"),

--- a/opennav_coverage_bt/src/compute_complete_coverage_path.cpp
+++ b/opennav_coverage_bt/src/compute_complete_coverage_path.cpp
@@ -31,6 +31,11 @@ ComputeCoveragePathAction::ComputeCoveragePathAction(
 void ComputeCoveragePathAction::on_tick()
 {
   // Get core inputs about what to perform
+  getInput("generate_decomp", goal_.generate_decomp);
+  std::string decomp_type;
+  getInput("decomp_mode_type", decomp_type);
+  goal_.decomp_mode.mode = decomp_type;
+  getInput("decomp_split_angle", goal_.decomp_mode.split_angle);
   getInput("generate_headland", goal_.generate_headland);
   getInput("generate_route", goal_.generate_route);
   getInput("generate_path", goal_.generate_path);

--- a/opennav_coverage_bt/test/test_compute_coverage_path.cpp
+++ b/opennav_coverage_bt/test/test_compute_coverage_path.cpp
@@ -33,6 +33,11 @@ public:
   : TestActionServer("compute_coverage_path")
   {}
 
+  const opennav_coverage_msgs::action::ComputeCoveragePath::Goal & getReceivedGoal() const
+  {
+    return last_goal_;
+  }
+
 protected:
   void execute(
     const typename std::shared_ptr<
@@ -41,6 +46,7 @@ protected:
   override
   {
     const auto goal = goal_handle->get_goal();
+    last_goal_ = *goal;
     auto result =
       std::make_shared<opennav_coverage_msgs::action::ComputeCoveragePath::Result>();
     result->nav_path.poses.resize(2);
@@ -48,6 +54,9 @@ protected:
     result->nav_path.poses[0].pose.position.x = 0.0;
     goal_handle->succeed(result);
   }
+
+private:
+  opennav_coverage_msgs::action::ComputeCoveragePath::Goal last_goal_;
 };
 
 class ComputeCoveragePathActionTestFixture : public ::testing::Test
@@ -149,6 +158,37 @@ TEST_F(ComputeCoveragePathActionTestFixture, test_tick)
   // halt node so another goal can be sent
   tree_->haltTree();
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::IDLE);
+}
+
+TEST_F(ComputeCoveragePathActionTestFixture, test_decomp_ports)
+{
+  // generate_decomp=true and decomp_mode_type must flow from the BT XML to the goal
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4" main_tree_to_execute="MainTree">
+        <BehaviorTree ID="MainTree">
+            <ComputeCoveragePath
+              nav_path="{path}"
+              generate_decomp="true"
+              decomp_mode_type="TRAPEZOIDAL"
+              decomp_split_angle="1.5708"/>
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
+    tree_->rootNode()->executeTick();
+  }
+  EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
+
+  // Verify the decomp ports reached the server goal
+  const auto & goal = action_server_->getReceivedGoal();
+  EXPECT_TRUE(goal.generate_decomp);
+  EXPECT_EQ(goal.decomp_mode.mode, std::string("TRAPEZOIDAL"));
+  EXPECT_NEAR(goal.decomp_mode.split_angle, 1.5708, 1e-4);
+
+  tree_->haltTree();
 }
 
 int main(int argc, char ** argv)

--- a/opennav_coverage_demo/params/demo_params.yaml
+++ b/opennav_coverage_demo/params/demo_params.yaml
@@ -10,6 +10,9 @@ coverage_server:
     default_allow_overlap: false
     default_swath_angle_type: "SET_ANGLE"
     default_swath_angle: 0.0 # We know its aligned for the demo
+    default_generate_decomp: false       # true enables decomposition for all missions
+    default_decomp_type: "NONE"          # NONE / TRAPEZOIDAL / BOUSTROPHEDON
+    default_decomp_split_angle: 0.0      # radians; 0 = split parallel to swath angle
 
 row_coverage_server:
   ros__parameters:

--- a/opennav_coverage_msgs/CMakeLists.txt
+++ b/opennav_coverage_msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(action_msgs REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Coordinate.msg"
   "msg/Coordinates.msg"
+  "msg/DecompMode.msg"
   "msg/HeadlandMode.msg"
   "msg/SwathMode.msg"
   "msg/RowSwathMode.msg"

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -1,6 +1,8 @@
 #goal definition
 
 # Whether to perform all 4 stages: Headlands, Swath (Required), Route, Path
+bool generate_decomp False
+opennav_coverage_msgs/DecompMode decomp_mode
 bool generate_headland True
 bool generate_route True
 bool generate_path True

--- a/opennav_coverage_msgs/msg/DecompMode.msg
+++ b/opennav_coverage_msgs/msg/DecompMode.msg
@@ -1,0 +1,4 @@
+string mode "UNKNOWN"  # NONE, TRAPEZOIDAL, BOUSTROPHEDON
+
+# Specific mode setting
+float64 split_angle 0.0  # split angle in radians; 0 = parallel to swath angle

--- a/opennav_coverage_msgs/msg/DecompMode.msg
+++ b/opennav_coverage_msgs/msg/DecompMode.msg
@@ -1,4 +1,4 @@
 string mode "UNKNOWN"  # NONE, TRAPEZOIDAL, BOUSTROPHEDON
 
 # Specific mode setting
-float64 split_angle 0.0  # split angle in radians; 0 = parallel to swath angle
+float64 split_angle 0.0  # split angle in radians; 0 = use node default (default_decomp_split_angle)


### PR DESCRIPTION
## Summary

Second PR in the series splitting the Fields2Cover (F2C) v2 enhancement branch
into reviewable chunks. Adds optional **field decomposition** — splitting a
non-convex field into sub-cells before swath/headland generation — plus the
`HL_SWATH` path handling that decomposed fields require. Builds on #112.

## Changes

**Field decomposition (core)**
- `DecompType` enum: `NONE`, `TRAPEZOIDAL`, `BOUSTROPHEDON`.
- `DecompGenerator`: wraps the Fields2Cover decomposition, selectable via mode
  and `split_angle`.
- Multi-cell overloads for the swath and headland generators, operating on the
  `F2CCells` produced by decomposition.
- Wired into `coverage_server` behind a single gate: the `generate_decomp` goal
  flag **or** a `default_generate_decomp` YAML parameter.
- BT node ports exposing decomposition control.

**HL_SWATH handling**
- Decomposition emits `HL_SWATH` states for inter-cell headland passes.
  `toCoveragePathMsg`/`toNavPathMsg` now treat `HL_SWATH` like `SWATH`, so
  decomposed fields no longer crash the server.

## Interface changes (additive)

- `DecompMode.msg` (new): `string mode` (`NONE`/`TRAPEZOIDAL`/`BOUSTROPHEDON`),
  `float64 split_angle` (radians; `0` = parallel to swath angle).
- `ComputeCoveragePath.action`: `+ bool generate_decomp`, `+ DecompMode decomp_mode`.
- `types.hpp`: `+ enum class DecompType`.

## Testing

- Decomposition + multi-cell swath/headland generation unit tests.
- `HL_SWATH` path-conversion test (velocity/direction fill with `HL_SWATH` states).

## Note

This adds the decomposition machinery and message/BT plumbing. The TSP route
planning that consumes the decomposed cells follows in the next PR of the series.
