### PR TITLE
Fix coverage path following on jazzy-v2 (F2C v2 swath densification)

### DIFF
--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -211,7 +211,6 @@ inline nav_msgs::msg::Path toNavPathMsg(
   const std_msgs::msg::Header & header, const bool is_cartesian,
   const float & pt_dist)
 {
-  using f2c::types::PathSectionType;
   nav_msgs::msg::Path msg;
   msg.header = header;
 
@@ -226,38 +225,12 @@ inline nav_msgs::msg::Path toNavPathMsg(
     path.moveTo(field.getRefPoint());
   }
 
-  for (unsigned int i = 0; i != path.size(); i++) {
-    // Swaths come in pairs of start-end sequentially
-    if (i > 0 && path[i].type == PathSectionType::SWATH &&
-      path[i - 1].type == PathSectionType::SWATH)
-    {
-      const float & x0 = path[i - 1].point.getX();
-      const float & y0 = path[i - 1].point.getY();
-      const float & x1 = path[i].point.getX();
-      const float & y1 = path[i].point.getY();
+  // discretizeSwath splits only SWATH states at pt_dist intervals, leaving dense turns intact.
+  path = path.discretizeSwath(static_cast<double>(pt_dist));
 
-      const float dist = hypotf(x1 - x0, y1 - y0);
-      const float ux = (x1 - x0) / dist;
-      const float uy = (y1 - y0) / dist;
-      float curr_dist = pt_dist;
-
-      geometry_msgs::msg::PoseStamped pose;
-      pose.pose.orientation =
-        nav2_util::geometry_utils::orientationAroundZAxis(path[i].angle);
-      pose.pose.position.x = x0;
-      pose.pose.position.y = y0;
-      pose.pose.position.z = path[i].point.getZ();
-
-      while (curr_dist < dist) {
-        pose.pose.position.x += pt_dist * ux;
-        pose.pose.position.y += pt_dist * uy;
-        msg.poses.push_back(pose);
-        curr_dist += pt_dist;
-      }
-    } else {
-      // Turns are already dense paths
-      msg.poses.push_back(toMsg(path[i]));
-    }
+  msg.poses.reserve(path.size());
+  for (const auto & state : path) {
+    msg.poses.push_back(toMsg(state));
   }
 
   return msg;

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -116,6 +116,14 @@ TEST(UtilsTests, TesttoNavPathMsg)
   auto msg = util::toNavPathMsg(path_in, field, header_in, true, 0.1);
   EXPECT_EQ(msg.header.frame_id, "test");
   EXPECT_EQ(msg.poses.size(), 10u);
+
+  // A single straight SWATH state must be densified: len 1.0 at pt_dist 0.1 -> ~10 poses.
+  Path swath_path;
+  swath_path.addState(
+    Point(0.0, 0.0), 0.0, 1.0,
+    f2c::types::PathDirection::FORWARD, f2c::types::PathSectionType::SWATH);
+  auto swath_msg = util::toNavPathMsg(swath_path, field, header_in, true, 0.1);
+  EXPECT_GE(swath_msg.poses.size(), 9u);
 }
 
 TEST(UtilsTests, TesttoCoveragePathMsg2)


### PR DESCRIPTION
### Problem
On jazzy-v2, `NavigateCompleteCoverage` drifts off the path and aborts with
`"Resulting plan has 0 poses in it."`

### Cause
`toNavPathMsg()` still uses the F2C v1 path model. In v2, `Path::appendSwath`
emits a single `PathState {point, angle, len}` per straight swath, so the
old two-consecutive-`SWATH` interpolation never fires and each straight row
collapses to one pose. Turns stay dense.

### Fix
Use F2C v2's native `Path::discretizeSwath()` (densifies only `SWATH`, keeps
turns). Signature unchanged, so `coverage_server`, `row_coverage_server` and
the RViz viz are all fixed via the shared header. Same fix already on `main`
(#110); this backports only the core change (not #112).
