### PR TITLE
Add TSP start pose, optional path reduce, and Rolling demo launch fix

### DIFF
--- a/opennav_coverage/include/opennav_coverage/path_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/path_generator.hpp
@@ -62,6 +62,14 @@ public:
       node, "default_turn_point_distance", rclcpp::ParameterValue(0.1));
     default_turn_point_distance_ = node->get_parameter("default_turn_point_distance").as_double();
 
+    nav2::declare_parameter_if_not_declared(
+      node, "default_reduce_path", rclcpp::ParameterValue(false));
+    reduce_path_ = node->get_parameter("default_reduce_path").as_bool();
+
+    nav2::declare_parameter_if_not_declared(
+      node, "default_reduce_min_dist", rclcpp::ParameterValue(0.1));
+    reduce_min_dist_ = node->get_parameter("default_reduce_min_dist").as_double();
+
     // Path Generator requires no changes at runtime
     generator_ = std::make_unique<f2c::pp::PathPlanning>();
     default_curve_ = createCurve(default_type_, default_continuity_type_);
@@ -96,6 +104,18 @@ public:
 
   float getTurnPointDistance() {return default_turn_point_distance_;}
 
+  /**
+   * @brief Enables/disables removing near-duplicate points from the path
+   * @param setting bool to enable path reduction
+   */
+  void setReducePath(const bool & setting) {reduce_path_ = setting;}
+
+  /**
+   * @brief Sets the minimum distance threshold used when reducing the path
+   * @param setting double minimum distance between kept points
+   */
+  void setReduceMinDist(const double & setting) {reduce_min_dist_ = setting;}
+
 protected:
   /**
    * @brief Creates generator pointer of a requested type
@@ -127,6 +147,8 @@ protected:
   PathType default_type_;
   PathContinuityType default_continuity_type_;
   float default_turn_point_distance_;
+  bool reduce_path_;
+  double reduce_min_dist_;
   TurningBasePtr default_curve_;
   std::unique_ptr<f2c::pp::PathPlanning> generator_;
   RobotParams * robot_params_;

--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -100,14 +100,14 @@ public:
    * @param cells Travel cells whose borders route connections may follow
    * @param swaths_by_cells Per-cell swaths from generateSwathsByCells
    * @param settings Action request information
-   * @param start_end Optional start/end point for the route (TSP mode only)
+   * @param start_end_point Optional start/end point for the route (TSP mode only)
    * @return F2CRoute (ordered swath groups plus any connections)
    */
   F2CRoute generateRoute(
     const F2CCells & cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
-    const std::optional<F2CPoint> & start_end = std::nullopt);
+    const std::optional<F2CPoint> & start_end_point = std::nullopt);
 
   /**
    * @brief Sets the mode manually of the Route for dynamic parameters

--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include <string>
+#include <optional>
 
 #include "fields2cover.h" // NOLINT
 
@@ -99,12 +100,14 @@ public:
    * @param cells Travel cells whose borders route connections may follow
    * @param swaths_by_cells Per-cell swaths from generateSwathsByCells
    * @param settings Action request information
+   * @param start_end Optional start/end point for the route (TSP mode only)
    * @return F2CRoute (ordered swath groups plus any connections)
    */
   F2CRoute generateRoute(
     const F2CCells & cells,
     const F2CSwathsByCells & swaths_by_cells,
-    const opennav_coverage_msgs::msg::RouteMode & settings);
+    const opennav_coverage_msgs::msg::RouteMode & settings,
+    const std::optional<F2CPoint> & start_end = std::nullopt);
 
   /**
    * @brief Sets the mode manually of the Route for dynamic parameters

--- a/opennav_coverage/include/opennav_coverage/route_method.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_method.hpp
@@ -44,14 +44,14 @@ public:
    * @param cells Travel cells whose borders the route connections may follow
    * @param swaths_by_cells Per-cell swaths to be covered
    * @param settings Fully-resolved RouteMode (server has already applied defaults)
-   * @param start_end Optional start/end point for the route (used by TSP only)
+   * @param start_end_point Optional start/end point for the route (used by TSP only)
    * @return Ordered route: swath groups plus any headland connections
    */
   virtual F2CRoute plan(
     const F2CCells & cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
-    const std::optional<F2CPoint> & start_end = std::nullopt) = 0;
+    const std::optional<F2CPoint> & start_end_point = std::nullopt) = 0;
 };
 
 /**
@@ -72,7 +72,7 @@ public:
     const F2CCells & cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
-    const std::optional<F2CPoint> & start_end = std::nullopt) override;
+    const std::optional<F2CPoint> & start_end_point = std::nullopt) override;
 
 private:
   RouteType type_;
@@ -95,7 +95,7 @@ public:
     const F2CCells & cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
-    const std::optional<F2CPoint> & start_end = std::nullopt) override;
+    const std::optional<F2CPoint> & start_end_point = std::nullopt) override;
 
 private:
   rclcpp::Logger logger_;

--- a/opennav_coverage/include/opennav_coverage/route_method.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_method.hpp
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <utility>
+#include <optional>
 
 #include "fields2cover.h" // NOLINT
 
@@ -43,12 +44,14 @@ public:
    * @param cells Travel cells whose borders the route connections may follow
    * @param swaths_by_cells Per-cell swaths to be covered
    * @param settings Fully-resolved RouteMode (server has already applied defaults)
+   * @param start_end Optional start/end point for the route (used by TSP only)
    * @return Ordered route: swath groups plus any headland connections
    */
   virtual F2CRoute plan(
     const F2CCells & cells,
     const F2CSwathsByCells & swaths_by_cells,
-    const opennav_coverage_msgs::msg::RouteMode & settings) = 0;
+    const opennav_coverage_msgs::msg::RouteMode & settings,
+    const std::optional<F2CPoint> & start_end = std::nullopt) = 0;
 };
 
 /**
@@ -68,7 +71,8 @@ public:
   F2CRoute plan(
     const F2CCells & cells,
     const F2CSwathsByCells & swaths_by_cells,
-    const opennav_coverage_msgs::msg::RouteMode & settings) override;
+    const opennav_coverage_msgs::msg::RouteMode & settings,
+    const std::optional<F2CPoint> & start_end = std::nullopt) override;
 
 private:
   RouteType type_;
@@ -90,7 +94,8 @@ public:
   F2CRoute plan(
     const F2CCells & cells,
     const F2CSwathsByCells & swaths_by_cells,
-    const opennav_coverage_msgs::msg::RouteMode & settings) override;
+    const opennav_coverage_msgs::msg::RouteMode & settings,
+    const std::optional<F2CPoint> & start_end = std::nullopt) override;
 
 private:
   rclcpp::Logger logger_;

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -339,6 +339,22 @@ inline F2CField getFieldFromGoal(
 }
 
 /**
+ * @brief Converts a goal-frame point into the frame the field's swaths/cells live in
+ * @param pt Point in the goal frame (cartesian or GPS)
+ * @param field Field already transformed to its working frame
+ * @param is_cartesian Whether the goal coordinates are cartesian
+ * @return Point in the field's local frame
+ */
+inline F2CPoint toFieldFrame(const F2CPoint & pt, const F2CField & field, bool is_cartesian)
+{
+  // F2CField always stores geometry with its ref point subtracted, so the start point needs
+  // the same ref point removed (and, for GPS, projecting to UTM first).
+  F2CPoint abs = is_cartesian ?
+    pt : f2c::Transform::transform(pt, field.getPrevCRS(), field.getCRS());
+  return abs - field.getRefPoint();
+}
+
+/**
  * @brief Converts a string to uppercase
  * @param string String to change to uppercase
  */

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -235,13 +235,13 @@ void CoverageServer::computeCoveragePath()
     header.frame_id = frame_id;
     Path path;
     if (goal->generate_route) {
-      std::optional<F2CPoint> start_end;
+      std::optional<F2CPoint> start_end_point;
       if (goal->use_start_pose) {
-        start_end = util::toFieldFrame(
+        start_end_point = util::toFieldFrame(
           F2CPoint(goal->start_pose.axis1, goal->start_pose.axis2), master_field, cartesian_frame_);
       }
       F2CRoute route =
-        route_gen_->generateRoute(route_cells, swaths_by_cells, goal->route_mode, start_end);
+        route_gen_->generateRoute(route_cells, swaths_by_cells, goal->route_mode, start_end_point);
       if (route.isEmpty()) {
         throw CoverageException("Route planner returned an empty route.");
       }

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -308,6 +308,8 @@ CoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramet
         swath_gen_->setStepAngle(parameter.as_double());
       } else if (name == "default_turn_point_distance") {
         path_gen_->setTurnPointDistance(parameter.as_double());
+      } else if (name == "default_reduce_min_dist") {
+        path_gen_->setReduceMinDist(parameter.as_double());
       } else if (name == "default_tsp_d_tol") {
         route_gen_->setTspDTol(parameter.as_double());
       } else if (name == "robot_width") {
@@ -340,6 +342,8 @@ CoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramet
         route_gen_->setTspRedirectSwaths(parameter.as_bool());
       } else if (name == "default_tsp_search_for_optimum") {
         route_gen_->setTspSearchForOptimum(parameter.as_bool());
+      } else if (name == "default_reduce_path") {
+        path_gen_->setReducePath(parameter.as_bool());
       }
     } else if (type == ParameterType::PARAMETER_INTEGER) {
       if (name == "default_spiral_n") {

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cmath>
+#include <optional>
 
 #include "opennav_coverage/coverage_server.hpp"
 
@@ -234,7 +235,13 @@ void CoverageServer::computeCoveragePath()
     header.frame_id = frame_id;
     Path path;
     if (goal->generate_route) {
-      F2CRoute route = route_gen_->generateRoute(route_cells, swaths_by_cells, goal->route_mode);
+      std::optional<F2CPoint> start_end;
+      if (goal->use_start_pose) {
+        start_end = util::toFieldFrame(
+          F2CPoint(goal->start_pose.axis1, goal->start_pose.axis2), master_field, cartesian_frame_);
+      }
+      F2CRoute route =
+        route_gen_->generateRoute(route_cells, swaths_by_cells, goal->route_mode, start_end);
       if (route.isEmpty()) {
         throw CoverageException("Route planner returned an empty route.");
       }

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -47,7 +47,13 @@ Path PathGenerator::generatePath(
     logger_,
     "Generating path with curve: %s", toString(action_type, action_continuity_type).c_str());
   curve->setDiscretization(turn_point_distance);
-  return generator_->planPath(robot_params_->getRobot(), route, *curve);
+  Path path = generator_->planPath(robot_params_->getRobot(), route, *curve);
+
+  // Optionally thin out near-duplicate points (e.g. in turns)
+  if (reduce_path_) {
+    path.reduce(reduce_min_dist_);
+  }
+  return path;
 }
 
 void PathGenerator::setPathMode(const std::string & new_mode)

--- a/opennav_coverage/src/route_generator.cpp
+++ b/opennav_coverage/src/route_generator.cpp
@@ -23,7 +23,8 @@ namespace opennav_coverage
 
 F2CRoute RouteGenerator::generateRoute(
   const F2CCells & cells, const F2CSwathsByCells & swaths_by_cells,
-  const opennav_coverage_msgs::msg::RouteMode & settings)
+  const opennav_coverage_msgs::msg::RouteMode & settings,
+  const std::optional<F2CPoint> & start_end)
 {
   RouteType action_type = toType(settings.mode);
 
@@ -49,8 +50,12 @@ F2CRoute RouteGenerator::generateRoute(
             "No valid route mode set! Options: BOUSTROPHEDON, SNAKE, SPIRAL, CUSTOM, TSP.");
   }
 
+  if (start_end && action_type != RouteType::TSP) {
+    RCLCPP_WARN(logger_, "start_pose ignored: only used in TSP route mode.");
+  }
+
   RCLCPP_DEBUG(logger_, "Generating route: %s", toString(action_type).c_str());
-  return method->plan(cells, swaths_by_cells, eff);
+  return method->plan(cells, swaths_by_cells, eff, start_end);
 }
 
 void RouteGenerator::setMode(const std::string & new_mode)

--- a/opennav_coverage/src/route_generator.cpp
+++ b/opennav_coverage/src/route_generator.cpp
@@ -24,7 +24,7 @@ namespace opennav_coverage
 F2CRoute RouteGenerator::generateRoute(
   const F2CCells & cells, const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end)
+  const std::optional<F2CPoint> & start_end_point)
 {
   RouteType action_type = toType(settings.mode);
 
@@ -50,12 +50,12 @@ F2CRoute RouteGenerator::generateRoute(
             "No valid route mode set! Options: BOUSTROPHEDON, SNAKE, SPIRAL, CUSTOM, TSP.");
   }
 
-  if (start_end && action_type != RouteType::TSP) {
+  if (start_end_point && action_type != RouteType::TSP) {
     RCLCPP_WARN(logger_, "start_pose ignored: only used in TSP route mode.");
   }
 
   RCLCPP_DEBUG(logger_, "Generating route: %s", toString(action_type).c_str());
-  return method->plan(cells, swaths_by_cells, eff, start_end);
+  return method->plan(cells, swaths_by_cells, eff, start_end_point);
 }
 
 void RouteGenerator::setMode(const std::string & new_mode)

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -25,8 +25,6 @@ F2CRoute SwathOrderMethod::plan(
   const opennav_coverage_msgs::msg::RouteMode & settings,
   const std::optional<F2CPoint> & /*start_end_point*/)
 {
-  // start_end_point is a TSP-only concept; the generator warns the user
-
   // The orderers assume a single cell; multi-cell (decomposed) input breaks their
   // ordering, so only TSP handles it. Reject rather than produce a bad route.
   if (cells.size() > 1) {

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -22,8 +22,11 @@ namespace opennav_coverage
 F2CRoute SwathOrderMethod::plan(
   const F2CCells & cells,
   const F2CSwathsByCells & swaths_by_cells,
-  const opennav_coverage_msgs::msg::RouteMode & settings)
+  const opennav_coverage_msgs::msg::RouteMode & settings,
+  const std::optional<F2CPoint> & start_end)
 {
+  (void)start_end;  // start/end is a TSP-only concept; the generator warns the user
+
   // The orderers assume a single cell; multi-cell (decomposed) input breaks their
   // ordering, so only TSP handles it. Reject rather than produce a bad route.
   if (cells.size() > 1) {
@@ -51,7 +54,8 @@ F2CRoute SwathOrderMethod::plan(
 F2CRoute TspRouteMethod::plan(
   const F2CCells & cells,
   const F2CSwathsByCells & swaths_by_cells,
-  const opennav_coverage_msgs::msg::RouteMode & settings)
+  const opennav_coverage_msgs::msg::RouteMode & settings,
+  const std::optional<F2CPoint> & start_end)
 {
   const bool redirect_swaths = settings.tsp_redirect_swaths;
   const long int time_limit = settings.tsp_time_limit;  // NOLINT
@@ -73,8 +77,19 @@ F2CRoute TspRouteMethod::plan(
   }
   if (total_swaths <= max_swaths_for_global_route_) {
     f2c::rp::RoutePlannerBase rp;
+    if (start_end) {
+      rp.setStartAndEndPoint(*start_end);
+    }
     return rp.genRoute(
       cells, swaths_by_cells, false, d_tol, redirect_swaths, time_limit, search_for_optimum);
+  }
+
+  // start_end can't be honored per-cell, so warn and drop it in the stitched fallback
+  if (start_end) {
+    RCLCPP_WARN(
+      logger_,
+      "start_pose ignored: swath count exceeds max_swaths_for_global_route; route is stitched "
+      "per-cell.");
   }
 
   // Fallback for large decompositions: solve each cell alone and stitch the

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -23,9 +23,9 @@ F2CRoute SwathOrderMethod::plan(
   const F2CCells & cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end)
+  const std::optional<F2CPoint> & /*start_end_point*/)
 {
-  (void)start_end;  // start/end is a TSP-only concept; the generator warns the user
+  // start_end_point is a TSP-only concept; the generator warns the user
 
   // The orderers assume a single cell; multi-cell (decomposed) input breaks their
   // ordering, so only TSP handles it. Reject rather than produce a bad route.
@@ -55,7 +55,7 @@ F2CRoute TspRouteMethod::plan(
   const F2CCells & cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end)
+  const std::optional<F2CPoint> & start_end_point)
 {
   const bool redirect_swaths = settings.tsp_redirect_swaths;
   const long int time_limit = settings.tsp_time_limit;  // NOLINT
@@ -77,15 +77,15 @@ F2CRoute TspRouteMethod::plan(
   }
   if (total_swaths <= max_swaths_for_global_route_) {
     f2c::rp::RoutePlannerBase rp;
-    if (start_end) {
-      rp.setStartAndEndPoint(*start_end);
+    if (start_end_point) {
+      rp.setStartAndEndPoint(*start_end_point);
     }
     return rp.genRoute(
       cells, swaths_by_cells, false, d_tol, redirect_swaths, time_limit, search_for_optimum);
   }
 
-  // start_end can't be honored per-cell, so warn and drop it in the stitched fallback
-  if (start_end) {
+  // start_end_point can't be honored per-cell, so warn and drop it in the stitched fallback
+  if (start_end_point) {
     RCLCPP_WARN(
       logger_,
       "start_pose ignored: swath count exceeds max_swaths_for_global_route; route is stitched "

--- a/opennav_coverage/test/test_route.cpp
+++ b/opennav_coverage/test/test_route.cpp
@@ -57,6 +57,20 @@ public:
   }
 };
 
+// Deterministic square field so B.9 start-point assertions aren't subject to random geometry
+static F2CCells makeSquareCells(double s)
+{
+  F2CLinearRing ring;
+  ring.addPoint(0.0, 0.0);
+  ring.addPoint(s, 0.0);
+  ring.addPoint(s, s);
+  ring.addPoint(0.0, s);
+  ring.addPoint(0.0, 0.0);
+  F2CCells cells;
+  cells.addGeometry(F2CCell(ring));
+  return cells;
+}
+
 TEST(RouteTests, TestrouteUtils)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
@@ -217,6 +231,89 @@ TEST(RouteTests, TestSwathOrderWrappedAsRoute)
     total_out += route.getVectorSwaths()[i].size();
   }
   EXPECT_EQ(sbc.sizeTotal(), total_out);
+}
+
+TEST(RouteTests, TestTSPStartPointHonored)
+{
+  // On the global route path, the route starts and returns at the given point
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeSquareCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "TSP";
+
+  F2CPoint start(0.0, 0.0);
+  F2CRoute route = generator.generateRoute(cells, sbc, settings, start);
+  EXPECT_FALSE(route.isEmpty());
+  EXPECT_NEAR(route.startPoint().getX(), start.getX(), 1e-2);
+  EXPECT_NEAR(route.startPoint().getY(), start.getY(), 1e-2);
+  EXPECT_NEAR(route.endPoint().getX(), start.getX(), 1e-2);
+  EXPECT_NEAR(route.endPoint().getY(), start.getY(), 1e-2);
+}
+
+TEST(RouteTests, TestTSPNoStartPointRegression)
+{
+  // No start point still produces a valid route
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeSquareCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "TSP";
+  F2CRoute route = generator.generateRoute(cells, sbc, settings);
+  EXPECT_FALSE(route.isEmpty());
+}
+
+TEST(RouteTests, TestNonTSPStartPointIgnored)
+{
+  // Orderer modes ignore the start point, producing an identical route
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeSquareCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "BOUSTROPHEDON";
+  F2CRoute without = generator.generateRoute(cells, sbc, settings);
+  F2CRoute with = generator.generateRoute(cells, sbc, settings, F2CPoint(0.0, 0.0));
+
+  EXPECT_EQ(without.asLineString().size(), with.asLineString().size());
+  EXPECT_NEAR(without.length(), with.length(), 1e-6);
+}
+
+TEST(RouteTests, TestTSPStitchIgnoresStartPoint)
+{
+  // The stitched fallback drops the start point but still produces a valid route
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeSquareCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  generator.setMaxSwathsForGlobalRoute(0);  // force the stitched fallback
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "TSP";
+  F2CRoute route = generator.generateRoute(cells, sbc, settings, F2CPoint(0.0, 0.0));
+  EXPECT_FALSE(route.isEmpty());
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_server.cpp
+++ b/opennav_coverage/test/test_server.cpp
@@ -46,6 +46,7 @@ public:
     this->on_configure(state);
     cartesian_frame_ = false;  // Test files in GPS
   }
+  void setCartesianFrame(bool v) {cartesian_frame_ = v;}
   void activate(const rclcpp_lifecycle::State & state) {this->on_activate(state);}
   void deactivate(const rclcpp_lifecycle::State & state) {this->on_deactivate(state);}
   void cleanup(const rclcpp_lifecycle::State & state) {this->on_cleanup(state);}
@@ -386,6 +387,7 @@ TEST(ServerTest, testTSPNoDecompPath)
   goal_msg.route_mode.mode = "TSP";
   goal_msg.route_mode.tsp_time_limit = 1;
   goal_msg.generate_path = true;
+  goal_msg.use_start_pose = false;  // baseline: start point unset
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const std::filesystem::path share_dir =
@@ -411,6 +413,113 @@ TEST(ServerTest, testTSPNoDecompPath)
   EXPECT_FALSE(result.result->coverage_path.swaths.empty());
   EXPECT_TRUE(result.result->coverage_path.contains_turns);
   EXPECT_TRUE(std::isfinite(result.result->task_time));
+}
+
+TEST(ServerTest, testTSPStartPose)
+{
+  // TSP with use_start_pose starts the path at the given GPS point
+  auto node = std::make_shared<ServerShim>();
+  rclcpp_lifecycle::State state;
+  node->configure(state);
+  node->activate(state);
+  auto node_thread = std::make_unique<nav2::NodeThread>(node);
+
+  auto client_node = std::make_shared<rclcpp::Node>("my_node_tsp_startpose");
+  auto action_client =
+    rclcpp_action::create_client<opennav_coverage_msgs::action::ComputeCoveragePath>(
+    client_node, "compute_coverage_path");
+  action_client->wait_for_action_server();
+
+  auto goal_msg = opennav_coverage_msgs::action::ComputeCoveragePath::Goal();
+  goal_msg.use_gml_file = true;
+  goal_msg.generate_decomp = false;
+  goal_msg.generate_headland = true;
+  goal_msg.generate_route = true;
+  goal_msg.route_mode.mode = "TSP";
+  goal_msg.route_mode.tsp_time_limit = 1;
+  goal_msg.generate_path = true;
+  goal_msg.use_start_pose = true;
+  // First outer-boundary vertex of test_field.xml (GPS); the route/path must begin here.
+  goal_msg.start_pose.axis1 = 4.26199990317851;
+  goal_msg.start_pose.axis2 = 51.7859704975047;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::filesystem::path share_dir =
+    ament_index_cpp::get_package_share_directory("opennav_coverage");
+#pragma GCC diagnostic pop
+  goal_msg.gml_field = (share_dir / "test_field.xml").string();
+
+  auto future_goal_handle = action_client->async_send_goal(goal_msg);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_goal_handle),
+    rclcpp::FutureReturnCode::SUCCESS);
+  auto goal_handle = future_goal_handle.get();
+
+  auto future_result = action_client->async_get_result(goal_handle);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_result),
+    rclcpp::FutureReturnCode::SUCCESS);
+
+  auto result = future_result.get();
+  EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
+  ASSERT_FALSE(result.result->nav_path.poses.empty());
+  // Output is GPS, so the first pose should sit at the requested start vertex
+  EXPECT_NEAR(result.result->nav_path.poses.front().pose.position.x, 4.26199990317851, 1e-4);
+  EXPECT_NEAR(result.result->nav_path.poses.front().pose.position.y, 51.7859704975047, 1e-4);
+}
+
+TEST(ServerTest, testTSPStartPoseCartesian)
+{
+  // Cartesian start pose must land at (5,5), not shifted by the field ref point
+  auto node = std::make_shared<ServerShim>();
+  rclcpp_lifecycle::State state;
+  node->configure(state);
+  node->setCartesianFrame(true);
+  node->activate(state);
+  auto node_thread = std::make_unique<nav2::NodeThread>(node);
+
+  auto client_node = std::make_shared<rclcpp::Node>("my_node_tsp_startpose_cart");
+  auto action_client =
+    rclcpp_action::create_client<opennav_coverage_msgs::action::ComputeCoveragePath>(
+    client_node, "compute_coverage_path");
+  action_client->wait_for_action_server();
+
+  auto goal_msg = opennav_coverage_msgs::action::ComputeCoveragePath::Goal();
+  goal_msg.frame_id = "map";
+  goal_msg.generate_headland = false;
+  goal_msg.generate_route = true;
+  goal_msg.generate_path = true;
+  goal_msg.route_mode.mode = "TSP";
+  goal_msg.route_mode.tsp_time_limit = 1;
+  goal_msg.use_start_pose = true;
+  goal_msg.start_pose.axis1 = 5.0;
+  goal_msg.start_pose.axis2 = 5.0;
+  goal_msg.polygons.resize(1);
+  for (const auto & xy : {std::pair<double, double>{5.0, 5.0}, {45.0, 5.0}, {45.0, 45.0},
+      {5.0, 45.0}, {5.0, 5.0}})
+  {
+    opennav_coverage_msgs::msg::Coordinate c;
+    c.axis1 = xy.first;
+    c.axis2 = xy.second;
+    goal_msg.polygons[0].coordinates.push_back(c);
+  }
+
+  auto future_goal_handle = action_client->async_send_goal(goal_msg);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_goal_handle),
+    rclcpp::FutureReturnCode::SUCCESS);
+  auto goal_handle = future_goal_handle.get();
+
+  auto future_result = action_client->async_get_result(goal_handle);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_result),
+    rclcpp::FutureReturnCode::SUCCESS);
+
+  auto result = future_result.get();
+  EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
+  ASSERT_FALSE(result.result->nav_path.poses.empty());
+  EXPECT_NEAR(result.result->nav_path.poses.front().pose.position.x, 5.0, 1e-3);
+  EXPECT_NEAR(result.result->nav_path.poses.front().pose.position.y, 5.0, 1e-3);
 }
 
 TEST(ServerTest, testDynamicParams)

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -46,6 +46,50 @@ TEST(UtilsTests, TestpointToPoint32)
   EXPECT_NEAR(pt_out.z, 1.2, 1e-6);
 }
 
+TEST(UtilsTests, TestToFieldFrameCartesian)
+{
+  // Cartesian start point is moved into the field's ref-subtracted local frame
+  F2CLinearRing ring;
+  ring.addPoint(5.0, 5.0);
+  ring.addPoint(15.0, 5.0);
+  ring.addPoint(15.0, 15.0);
+  ring.addPoint(5.0, 5.0);
+  F2CCells cells;
+  cells.addGeometry(F2CCell(ring));
+  F2CField field(cells);
+  ASSERT_DOUBLE_EQ(field.getRefPoint().getX(), 5.0);  // F2CField subtracts the first vertex
+  ASSERT_DOUBLE_EQ(field.getRefPoint().getY(), 5.0);
+
+  // The field corner (5,5) maps to the local origin; (10,8) maps to (5,3)
+  F2CPoint corner = util::toFieldFrame(F2CPoint(5.0, 5.0), field, true);
+  EXPECT_DOUBLE_EQ(corner.getX(), 0.0);
+  EXPECT_DOUBLE_EQ(corner.getY(), 0.0);
+  F2CPoint inside = util::toFieldFrame(F2CPoint(10.0, 8.0), field, true);
+  EXPECT_DOUBLE_EQ(inside.getX(), 5.0);
+  EXPECT_DOUBLE_EQ(inside.getY(), 3.0);
+}
+
+TEST(UtilsTests, TestToFieldFrameGPS)
+{
+  // GPS start point lands in the field's local frame
+  F2CLinearRing ring;
+  ring.addPoint(-1.0, 40.0);
+  ring.addPoint(-1.0, 40.001);
+  ring.addPoint(-0.999, 40.001);
+  ring.addPoint(-0.999, 40.0);
+  ring.addPoint(-1.0, 40.0);
+  F2CCells cells;
+  cells.addGeometry(F2CCell(ring));
+  F2CField field(cells);
+  field.setCRS("EPSG:4326");
+  f2c::Transform::transformToUTM(field);
+
+  // The first ring vertex is the field's reference, so it maps to the local origin
+  F2CPoint local = util::toFieldFrame(F2CPoint(-1.0, 40.0), field, false);
+  EXPECT_NEAR(local.getX(), 0.0, 1e-3);
+  EXPECT_NEAR(local.getY(), 0.0, 1e-3);
+}
+
 TEST(UtilsTests, TestpointToMsg)
 {
   Point pt_in{1.0, 2.0, 3.0};

--- a/opennav_coverage_bt/include/opennav_coverage_bt/compute_complete_coverage_path.hpp
+++ b/opennav_coverage_bt/include/opennav_coverage_bt/compute_complete_coverage_path.hpp
@@ -22,6 +22,7 @@
 #include "opennav_coverage_msgs/action/compute_coverage_path.hpp"
 #include "nav2_behavior_tree/bt_action_node.hpp"
 #include "geometry_msgs/msg/polygon.hpp"
+#include "geometry_msgs/msg/point.hpp"
 #include "opennav_coverage_bt/utils.hpp"
 
 namespace opennav_coverage_bt
@@ -102,6 +103,9 @@ public:
         BT::InputPort<int>("tsp_time_limit", 1, "TSP: OR-Tools time limit in seconds"),
         BT::InputPort<bool>("tsp_search_for_optimum", false, "TSP: guided local search"),
         BT::InputPort<double>("tsp_d_tol", 0.0001, "TSP: distance tolerance for OR-Tools"),
+        BT::InputPort<bool>("use_start_pose", false, "TSP: start/return route at start_pose"),
+        BT::InputPort<geometry_msgs::msg::Point>(
+          "start_pose", "TSP: route start/return point, in the polygons' frame"),
 
         BT::InputPort<std::string>("file_field", "Filepath to field GML file"),
         BT::InputPort<int>("file_field_id", 0, "Ordered ID of which field to use in GML File"),

--- a/opennav_coverage_bt/src/compute_complete_coverage_path.cpp
+++ b/opennav_coverage_bt/src/compute_complete_coverage_path.cpp
@@ -53,6 +53,14 @@ void ComputeCoveragePathAction::on_tick()
   getInput("tsp_search_for_optimum", goal_.route_mode.tsp_search_for_optimum);
   getInput("tsp_d_tol", goal_.route_mode.tsp_d_tol);
 
+  // TSP start/return point
+  getInput("use_start_pose", goal_.use_start_pose);
+  geometry_msgs::msg::Point start_pose;
+  if (getInput("start_pose", start_pose)) {
+    goal_.start_pose.axis1 = start_pose.x;
+    goal_.start_pose.axis2 = start_pose.y;
+  }
+
   // Get the field to get coverage for
   std::string gml_filename;
   if (getInput("file_field", gml_filename)) {

--- a/opennav_coverage_bt/test/test_compute_coverage_path.cpp
+++ b/opennav_coverage_bt/test/test_compute_coverage_path.cpp
@@ -19,6 +19,7 @@
 
 #include "nav_msgs/msg/path.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
+#include "geometry_msgs/msg/point.hpp"
 
 #include "behaviortree_cpp/bt_factory.h"
 
@@ -221,6 +222,40 @@ TEST_F(ComputeCoveragePathActionTestFixture, test_tsp_ports)
   EXPECT_EQ(goal.route_mode.tsp_time_limit, 3u);
   EXPECT_TRUE(goal.route_mode.tsp_search_for_optimum);
   EXPECT_NEAR(goal.route_mode.tsp_d_tol, 0.0005, 1e-9);
+
+  tree_->haltTree();
+}
+
+TEST_F(ComputeCoveragePathActionTestFixture, test_start_pose_ports)
+{
+  // use_start_pose and start_pose flow from BT XML/blackboard to the goal
+  geometry_msgs::msg::Point start;
+  start.x = 5.0;
+  start.y = 7.0;
+  config_->blackboard->set<geometry_msgs::msg::Point>("start_pt", start);
+
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4" main_tree_to_execute="MainTree">
+        <BehaviorTree ID="MainTree">
+            <ComputeCoveragePath
+              nav_path="{path}"
+              use_start_pose="true"
+              start_pose="{start_pt}"/>
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
+    tree_->rootNode()->executeTick();
+  }
+  EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
+
+  const auto & goal = action_server_->getReceivedGoal();
+  EXPECT_TRUE(goal.use_start_pose);
+  EXPECT_NEAR(goal.start_pose.axis1, 5.0, 1e-6);
+  EXPECT_NEAR(goal.start_pose.axis2, 7.0, 1e-6);
 
   tree_->haltTree();
 }

--- a/opennav_coverage_demo/launch/coverage_demo_launch.py
+++ b/opennav_coverage_demo/launch/coverage_demo_launch.py
@@ -103,7 +103,11 @@ def generate_launch_description():
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['5.0', '5.0', '0', '0', '0', '0', 'map', 'odom'],
+        arguments=[
+            '--x', '5.0', '--y', '5.0', '--z', '0',
+            '--yaw', '0', '--pitch', '0', '--roll', '0',
+            '--frame-id', 'map', '--child-frame-id', 'odom',
+        ],
     )
 
     # start the demo task

--- a/opennav_coverage_demo/launch/row_coverage_demo_launch.py
+++ b/opennav_coverage_demo/launch/row_coverage_demo_launch.py
@@ -103,13 +103,21 @@ def generate_launch_description():
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['6.23', '15', '0', '0', '0', '0', 'map', 'odom'],
+        arguments=[
+            '--x', '6.23', '--y', '15', '--z', '0',
+            '--yaw', '0', '--pitch', '0', '--roll', '0',
+            '--frame-id', 'map', '--child-frame-id', 'odom',
+        ],
     )
     fake_gps_cmd = Node(
         package='tf2_ros',
         executable='static_transform_publisher',
         output='screen',
-        arguments=['0', '0', '0', '0', '0', '0', 'EPSG:4258', 'map'],
+        arguments=[
+            '--x', '0', '--y', '0', '--z', '0',
+            '--yaw', '0', '--pitch', '0', '--roll', '0',
+            '--frame-id', 'EPSG:4258', '--child-frame-id', 'map',
+        ],
     )
 
     # start the demo task

--- a/opennav_coverage_demo/params/demo_params.yaml
+++ b/opennav_coverage_demo/params/demo_params.yaml
@@ -38,7 +38,7 @@ bt_navigator:
     navigators: ['navigate_complete_coverage']
     navigate_complete_coverage:
       plugin: "opennav_coverage_navigator/CoverageNavigator"
-    error_code_names: ["compute_path_error_code", "follow_path_error_code", "compute_coverage_error_code"]
+    error_code_name_prefixes: ["compute_path", "follow_path", "compute_coverage"]
     plugin_lib_names:
       - opennav_compute_complete_coverage_action_bt_node
       - opennav_cancel_complete_coverage_action_bt_node

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -23,6 +23,10 @@ opennav_coverage_msgs/RowSwathMode row_swath_mode
 opennav_coverage_msgs/RouteMode route_mode
 opennav_coverage_msgs/PathMode path_mode
 
+# TSP-only: start and return the route at this point, in the same frame as polygons
+bool use_start_pose False
+opennav_coverage_msgs/Coordinate start_pose
+
 ---
 #result definition
 


### PR DESCRIPTION
## Summary

Three small, independent improvements to the coverage server. Each change is opt-in or behavior-preserving by default, so this PR is backwards compatible.

1. Optional TSP start/return pose
2. Optional path point reduction
3. Rolling demo launch fix

## 1. TSP start pose

Adds two goal fields to `ComputeCoveragePath`:

```
bool use_start_pose False
opennav_coverage_msgs/Coordinate start_pose
```

When `use_start_pose` is true and `route_mode` is TSP, the route starts and returns at `start_pose` (via `RoutePlannerBase::setStartAndEndPoint`). The point is given in the same frame as `polygons` and converted into the field's local frame, handling both the GPS/UTM and cartesian paths. For non-TSP route modes the start pose is ignored with a warning. The point is also exposed through the `ComputeCoveragePath` behavior-tree node ports.

## 2. Optional path reduce

Adds two dynamic parameters:

- `default_reduce_path` (bool, default `false`)
- `default_reduce_min_dist` (double, default `0.1`)

When enabled, `generatePath` runs F2C's `Path::reduce` to drop near-duplicate points (e.g. in turns). Default off, so the path output is unchanged unless explicitly requested.

## 3. Rolling demo launch fix

- `static_transform_publisher` doesn't accept positional arguments on Rolling; switched to named `--x/--y/.../--frame-id` flags in `coverage_demo_launch.py` and `row_coverage_demo_launch.py`.
- `bt_navigator` renamed `error_code_names` to `error_code_name_prefixes`; the old key threw during `CoverageNavigator` configure and segfaulted the component container, so the demo never came up.
