### PR TITLE
Add task time, per-pose velocity/direction, and NSwathModified swath objective (humble)

### DIFF
--- a/opennav_coverage/CMakeLists.txt
+++ b/opennav_coverage/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(GDAL REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
 set(CMAKE_CXX_STANDARD 17)
-add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference)
+add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference -Wno-error=null-dereference)
 
 include_directories(
   include

--- a/opennav_coverage/include/opennav_coverage/types.hpp
+++ b/opennav_coverage/include/opennav_coverage/types.hpp
@@ -61,7 +61,8 @@ enum class SwathType
   UNKNOWN = 0,
   LENGTH = 1,
   NUMBER = 2,
-  COVERAGE = 3
+  COVERAGE = 3,
+  NUMBER_MODIFIED = 4
 };
 
 /**

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -204,15 +204,21 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
  * @param Field Field to use for conversion from UTM if necessary
  * @param header header
  * @param bool if the origional CRS is cartesian or not requiring conversion
+ * @param out_velocities Optional: if non-null, filled with per-pose velocity (m/s), parallel to poses
+ * @param out_is_backward Optional: if non-null, filled with per-pose reverse-direction flags
  * @return nav_msgs/Path Path
  */
 inline nav_msgs::msg::Path toNavPathMsg(
   const Path & raw_path, const F2CField & field,
   const std_msgs::msg::Header & header, const bool is_cartesian,
-  const float & pt_dist)
+  const float & pt_dist,
+  std::vector<double> * out_velocities = nullptr,
+  std::vector<bool> * out_is_backward = nullptr)
 {
   nav_msgs::msg::Path msg;
   msg.header = header;
+  if (out_velocities) {out_velocities->clear();}
+  if (out_is_backward) {out_is_backward->clear();}
 
   if (raw_path.size() == 0) {
     return msg;
@@ -228,9 +234,18 @@ inline nav_msgs::msg::Path toNavPathMsg(
   // discretizeSwath splits only SWATH states at pt_dist intervals, leaving dense turns intact.
   path = path.discretizeSwath(static_cast<double>(pt_dist));
 
-  msg.poses.reserve(path.size());
+  // Reserve up front so the population loop below doesn't reallocate.
+  const auto n = path.size();
+  msg.poses.reserve(n);
+  if (out_velocities) {out_velocities->reserve(n);}
+  if (out_is_backward) {out_is_backward->reserve(n);}
+
   for (const auto & state : path) {
     msg.poses.push_back(toMsg(state));
+    if (out_velocities) {out_velocities->push_back(state.velocity);}
+    if (out_is_backward) {
+      out_is_backward->push_back(state.dir == f2c::types::PathDirection::BACKWARD);
+    }
   }
 
   return msg;

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
+
 #include "opennav_coverage/coverage_server.hpp"
 
 using namespace std::chrono_literals;
@@ -218,6 +220,8 @@ void CoverageServer::computeCoveragePath()
         result->nav_path = util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
           &result->coverage_path.velocities, &result->coverage_path.is_backward);
+        const double task_time = path.getTaskTime();
+        result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {
         result->coverage_path =
           util::toCoveragePathMsg(route, master_field, true, header, cartesian_frame_);

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -216,7 +216,8 @@ void CoverageServer::computeCoveragePath()
         result->coverage_path =
           util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = util::toNavPathMsg(
-          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance());
+          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
+          &result->coverage_path.velocities, &result->coverage_path.is_backward);
       } else {
         result->coverage_path =
           util::toCoveragePathMsg(route, master_field, true, header, cartesian_frame_);

--- a/opennav_coverage/src/swath_generator.cpp
+++ b/opennav_coverage/src/swath_generator.cpp
@@ -80,6 +80,8 @@ SwathObjectivePtr SwathGenerator::createObjective(const SwathType & type)
       return std::move(std::make_shared<f2c::obj::NSwath>());
     case SwathType::COVERAGE:
       return std::move(std::make_shared<f2c::obj::FieldCoverage>());
+    case SwathType::NUMBER_MODIFIED:
+      return std::move(std::make_shared<f2c::obj::NSwathModified>());
     default:
       RCLCPP_WARN(logger_, "Unknown swath type set!");
       return SwathObjectivePtr{nullptr};
@@ -98,6 +100,9 @@ std::string SwathGenerator::toString(const SwathType & type, const SwathAngleTyp
       break;
     case SwathType::COVERAGE:
       str = "Coverage";
+      break;
+    case SwathType::NUMBER_MODIFIED:
+      str = "Number Modified";
       break;
     default:
       str = "Unknown";
@@ -132,6 +137,8 @@ SwathType SwathGenerator::toType(const std::string & str)
     return SwathType::NUMBER;
   } else if (mode_str == "COVERAGE") {
     return SwathType::COVERAGE;
+  } else if (mode_str == "NUMBER_MODIFIED") {
+    return SwathType::NUMBER_MODIFIED;
   } else {
     return SwathType::UNKNOWN;
   }

--- a/opennav_coverage/test/test_swath.cpp
+++ b/opennav_coverage/test/test_swath.cpp
@@ -81,16 +81,23 @@ TEST(SwathTests, TestswathUtils)
   EXPECT_EQ(generator.toTypeShim("number"), SwathType::NUMBER);
   EXPECT_EQ(generator.toTypeShim("COVERAGE"), SwathType::COVERAGE);
   EXPECT_EQ(generator.toTypeShim("coverage"), SwathType::COVERAGE);
-
+  EXPECT_EQ(generator.toTypeShim("NUMBER_MODIFIED"), SwathType::NUMBER_MODIFIED);
+  EXPECT_EQ(generator.toTypeShim("number_modified"), SwathType::NUMBER_MODIFIED);
 
   EXPECT_EQ(generator.toStringShim(SwathType::NUMBER, SwathAngleType::SET_ANGLE).size(), 37u);
   EXPECT_EQ(generator.toStringShim(SwathType::COVERAGE, SwathAngleType::BRUTE_FORCE).size(), 41u);
   EXPECT_GT(generator.toStringShim(SwathType::UNKNOWN, SwathAngleType::UNKNOWN).size(), 20u);
   EXPECT_GT(generator.toStringShim(SwathType::UNKNOWN, SwathAngleType::BRUTE_FORCE).size(), 20u);
 
+  EXPECT_EQ(
+    generator.toStringShim(SwathType::NUMBER_MODIFIED, SwathAngleType::BRUTE_FORCE).size(), 48u);
+  EXPECT_EQ(
+    generator.toStringShim(SwathType::NUMBER_MODIFIED, SwathAngleType::SET_ANGLE).size(), 46u);
+
   EXPECT_TRUE(generator.createObjectiveShim(SwathType::LENGTH));
   EXPECT_TRUE(generator.createObjectiveShim(SwathType::NUMBER));
   EXPECT_TRUE(generator.createObjectiveShim(SwathType::COVERAGE));
+  EXPECT_TRUE(generator.createObjectiveShim(SwathType::NUMBER_MODIFIED));
   EXPECT_FALSE(generator.createObjectiveShim(SwathType::UNKNOWN));
 
   generator.setSwathAngleMode("NUMBER");
@@ -119,6 +126,9 @@ TEST(SwathTests, TestswathGeneration)
   settings.mode = "SET_ANGLE";
   settings.objective = "NUMBER";
   auto swaths3 = generator.generateSwaths(field.getField().getGeometry(0), settings);
+  settings.mode = "BRUTE_FORCE";
+  settings.objective = "NUMBER_MODIFIED";
+  auto swaths4 = generator.generateSwaths(field.getField().getGeometry(0), settings);
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <utility>
 
 #include "gtest/gtest.h"
@@ -209,6 +210,71 @@ TEST(UtilsTests, TestgetFieldFromGoal)
   goal->polygons[1].coordinates[0].axis1 = 1.0;
   auto field2 = util::getFieldFromGoal(goal);
   EXPECT_EQ(field2.getField().getGeometry(0).getGeometry(1).size(), 3u);
+}
+
+TEST(UtilsTests, TesttoNavPathMsgDiscreteSwathPointCount)
+{
+  // A single SWATH state with len=1.0 at step=0.1 → n_steps = round(1.0/0.1) = 10
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+  PathState s;
+  s.type = f2c::types::PathSectionType::SWATH;
+  s.point = Point(0.0, 0.0);
+  s.len = 1.0;
+  s.angle = 0.0;
+  path_in.addState(s);
+  F2CField field;
+
+  auto msg = util::toNavPathMsg(path_in, field, header_in, true, 0.1f);
+  EXPECT_EQ(msg.poses.size(), 10u);
+}
+
+TEST(UtilsTests, TesttoNavPathMsgTurnUnchanged)
+{
+  // TURN states must pass through discretizeSwath unmodified (regression guard)
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+  path_in.getStates().resize(10);
+  for (auto & state : path_in.getStates()) {
+    state.type = f2c::types::PathSectionType::TURN;
+  }
+  F2CField field;
+
+  auto msg = util::toNavPathMsg(path_in, field, header_in, true, 0.1f);
+  EXPECT_EQ(msg.poses.size(), 10u);
+}
+
+TEST(UtilsTests, TestGetTaskTime)
+{
+  Path path;
+  PathState s;
+  s.len = 5.0;
+  s.velocity = 2.0;
+  path.addState(s);
+
+  EXPECT_NEAR(path.getTaskTime(), 2.5, 0.01);
+}
+
+TEST(UtilsTests, TestGetTaskTimeZeroVelocity)
+{
+  // velocity=0 → getTaskTime() returns inf; caller must guard with std::isfinite
+  Path path;
+  PathState s;
+  s.len = 1.0;
+  s.velocity = 0.0;
+  path.addState(s);
+
+  EXPECT_FALSE(std::isfinite(path.getTaskTime()));
+  const double guarded = std::isfinite(path.getTaskTime()) ? path.getTaskTime() : 0.0;
+  EXPECT_NEAR(guarded, 0.0, 1e-9);
+}
+
+TEST(UtilsTests, TestGetTaskTimeEmptyPath)
+{
+  Path empty;
+  EXPECT_NEAR(empty.getTaskTime(), 0.0, 1e-9);
 }
 
 TEST(UtilsTests, TestPathComponentsIterator)

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -250,4 +250,119 @@ TEST(UtilsTests, TestPathComponentsIterator)
   EXPECT_EQ(std::get<1>(last_row_info), nullptr);
 }
 
+// B.6-T2: empty path → velocity and is_backward vectors are empty
+TEST(UtilsTests, TesttoNavPathMsgEmptyVelocity)
+{
+  std_msgs::msg::Header header_in;
+  Path empty_path;
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+
+  auto nav_path = util::toNavPathMsg(empty_path, field, header_in, true, 0.1f, &vels, &dirs);
+  EXPECT_TRUE(nav_path.poses.empty());
+  EXPECT_TRUE(vels.empty());
+  EXPECT_TRUE(dirs.empty());
+}
+
+// B.6-T3: forward-only path → all is_backward entries are false
+TEST(UtilsTests, TesttoNavPathMsgForwardOnly)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+  PathState s;
+  s.type = f2c::types::PathSectionType::SWATH;
+  s.point = Point(0.0, 0.0);
+  s.len = 1.0;
+  s.angle = 0.0;
+  s.velocity = 1.5;
+  s.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(s);
+  F2CField field;
+
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  for (const auto & d : dirs) {
+    EXPECT_FALSE(d);
+  }
+  for (const auto & v : vels) {
+    EXPECT_NEAR(v, 1.5, 1e-6);
+  }
+}
+
+// B.6-T1: velocity and is_backward values match PathState fields after discretizeSwath
+TEST(UtilsTests, TesttoNavPathMsgWithVelocity)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState swath;
+  swath.type = f2c::types::PathSectionType::SWATH;
+  swath.point = Point(0.0, 0.0);
+  swath.len = 1.0;
+  swath.angle = 0.0;
+  swath.velocity = 2.0;
+  swath.dir = f2c::types::PathDirection::BACKWARD;
+  path_in.addState(swath);
+
+  PathState turn;
+  turn.type = f2c::types::PathSectionType::TURN;
+  turn.velocity = 0.5;
+  turn.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(turn);
+
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  // SWATH states: velocity=2.0, direction=BACKWARD
+  EXPECT_NEAR(vels[0], 2.0, 1e-6);
+  EXPECT_TRUE(dirs[0]);
+  // TURN state: velocity=0.5, direction=FORWARD
+  EXPECT_NEAR(vels.back(), 0.5, 1e-6);
+  EXPECT_FALSE(dirs.back());
+}
+
+// B.6+B.7 integration: poses, velocities, is_backward sizes must match after discretizeSwath
+TEST(UtilsTests, TesttoNavPathMsgDensifyVelocitySizeMatch)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState swath;
+  swath.type = f2c::types::PathSectionType::SWATH;
+  swath.len = 1.0;
+  swath.velocity = 1.5;
+  swath.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(swath);
+
+  PathState turn;
+  turn.type = f2c::types::PathSectionType::TURN;
+  turn.velocity = 0.5;
+  turn.dir = f2c::types::PathDirection::BACKWARD;
+  path_in.addState(turn);
+  path_in.addState(turn);
+
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  // SWATH poses are forward; TURN poses are backward
+  EXPECT_FALSE(dirs[0]);
+  EXPECT_TRUE(dirs.back());
+}
+
 }  // namespace opennav_coverage

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -35,6 +35,7 @@ uint16 INVALID_COORDS=803
 nav_msgs/Path nav_path
 opennav_coverage_msgs/PathComponents coverage_path
 builtin_interfaces/Duration planning_time
+float64 task_time
 uint16 error_code
 
 ---

--- a/opennav_coverage_msgs/msg/PathComponents.msg
+++ b/opennav_coverage_msgs/msg/PathComponents.msg
@@ -4,3 +4,8 @@ opennav_coverage_msgs/Swath[] swaths
 nav_msgs/Path[] turns
 bool contains_turns
 bool swaths_ordered
+
+# Per-pose velocity (m/s) and direction flags, parallel to nav_path.poses.
+# Populated only when generate_path=true. Empty when path is not generated.
+float64[] velocities
+bool[] is_backward

--- a/opennav_coverage_msgs/msg/SwathMode.msg
+++ b/opennav_coverage_msgs/msg/SwathMode.msg
@@ -1,4 +1,4 @@
-string objective "UNKNOWN"  # LENGTH, NUMBER, or COVERAGE
+string objective "UNKNOWN"  # LENGTH, NUMBER, NUMBER_MODIFIED, or COVERAGE
 string mode "UNKNOWN"  # BRUTE_FORCE, SET_ANGLE
 
 # Specific mode settings

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -214,7 +214,8 @@ void RowCoverageServer::computeCoveragePath()
         result->coverage_path =
           opennav_coverage::util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = opennav_coverage::util::toNavPathMsg(
-          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance());
+          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
+          &result->coverage_path.velocities, &result->coverage_path.is_backward);
       } else {
         result->coverage_path =
           opennav_coverage::util::toCoveragePathMsg(

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
+
 #include "opennav_row_coverage/row_coverage_server.hpp"
 
 using namespace std::chrono_literals;
@@ -216,6 +218,8 @@ void RowCoverageServer::computeCoveragePath()
         result->nav_path = opennav_coverage::util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
           &result->coverage_path.velocities, &result->coverage_path.is_backward);
+        const double task_time = path.getTaskTime();
+        result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {
         result->coverage_path =
           opennav_coverage::util::toCoveragePathMsg(


### PR DESCRIPTION
## Summary

It bundles three small, self-contained output/objective improvements plus one build fix.


This is the humble counterpart of #112 (which targeted the rolling/`main`
branch). The changes are the same, adapted to humble:
- The `discretizeSwath` swath refactor from #112 already landed on humble via the
  straight-swath collapse bugfix, so here `toNavPathMsg` only *gains* the
  per-pose velocity/direction population on top of it.

> **Note:** Same changes as #121 (the jazzy counterpart), adapted to humble.

## Changes

**1. Per-pose velocity and direction on `PathComponents`**
**2. Task time on the action result**
**3. `NUMBER_MODIFIED` swath objective**
**4. Build fix: keep `-Wnull-dereference` non-fatal**

## Interface changes (all additive)

- `PathComponents.msg`: `+ float64[] velocities`, `+ bool[] is_backward`
- `ComputeCoveragePath.action` (result): `+ float64 task_time`
- `SwathMode.msg`: `objective` now also accepts `NUMBER_MODIFIED` (doc comment updated)
