### PR TITLE
Add task time, per-pose velocity/direction, and NSwathModified swath objective (Lyrical)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,6 +147,21 @@ jobs:
           sudo touch -d '2026-01-01 00:00:00 UTC' "$hdr"
         fi
 
+    - name: Shim launch_testing pytest hookspec (module_path)
+      # ros2-testing ships launch_testing_ros 0.29.9 (hookimpl renamed path
+      # -> module_path, ros2/launch#972) but launch_testing 3.9.7 predates
+      # the matching hookspec change, so pytest aborts at plugin registration
+      # and every python test errors. Align hookspec + call site with current
+      # rolling (accepts both names); no-op once a fixed launch_testing ships.
+      run: |
+        sp=$(ls -d /opt/ros/${{ matrix.ros_distro }}/lib/python3*/site-packages)
+        hs=$sp/launch_testing/pytest/hookspecs.py
+        if [ -f "$hs" ] && ! grep -q module_path "$hs"; then
+          sudo sed -i 's/^def pytest_launch_collect_makemodule(path, parent, entrypoint):/def pytest_launch_collect_makemodule(module_path, path, parent, entrypoint):/' "$hs"
+          sudo sed -i 's/path=path, parent=parent, entrypoint=entrypoint/module_path=path, path=path, parent=parent, entrypoint=entrypoint/' \
+            "$sp/launch_testing/pytest/hooks.py"
+        fi
+
     - name: Compute environment fingerprint
       # dpkg hash after all apt/rosdep steps. The :master image is rebuilt
       # nightly; a build tree must only be reused in the environment it was

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,8 @@ jobs:
     env:
       ROS_DISTRO: ${{ matrix.ros_distro }}
       RMW_IMPLEMENTATION: rmw_cyclonedds_cpp
-      # Ubuntu 26.04 ships CMake 4.x, which hard-errors on dependencies that
-      # declare cmake_minimum_required(VERSION < 3.5) (e.g. the zlib bundled by
-      # ortools_vendor's OR-Tools). This lets CMake 4 accept those old minimums;
-      # it propagates into nested FetchContent/ExternalProject sub-builds too.
+      # CMake 4 (Ubuntu 26.04) rejects deps declaring cmake_minimum_required
+      # < 3.5 (e.g. OR-Tools' bundled zlib); accept them in sub-builds too.
       CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     container:
       image: ghcr.io/ros-tooling/setup-ros-docker/setup-ros-docker-ubuntu-resolute-ros-lyrical-ros-base:master
@@ -22,69 +20,86 @@ jobs:
       fail-fast: false
       matrix:
           ros_distro: [lyrical]
-    # ROS Rolling has been released as Lyrical on Ubuntu 26.04 (resolute), where
-    # the apt repo is consistent and rosdep works. nav2 (navigation2 main) and
-    # Fields2Cover are not released as binaries there, so they are built from
-    # source via deps.repos. We drive the build manually instead of
-    # action-ros-ci because nav2 main needs a source patch (-Werror) applied
-    # between vcs import and colcon build, which action-ros-ci does not allow.
+    # ROS Rolling has been released as Lyrical on Ubuntu 26.04 (resolute), which
+    # has no nav2 or Fields2Cover binaries: they are built from source via
+    # deps.repos, with source patches applied between import and build (which
+    # action-ros-ci disallows).
     steps:
     - uses: actions/checkout@v4
       with:
         path: ros_ws/src/opennav_coverage
 
     - name: Install system dependencies
-      # libompl-dev: nav2_smac_planner's find_package(ompl) -- rosdep cannot
-      #   resolve the 'ompl' key on Lyrical (no ros-lyrical-ompl).
-      # The rest: Fields2Cover (gdal/eigen/geos/tinyxml2), tinyxml2-vendor for
-      #   opennav_row_coverage, Cyclone DDS, and vcstool/colcon.
+      # Deps rosdep can't (reliably) resolve on resolute: Fields2Cover build
+      # deps (gdal/eigen/geos/tinyxml2/OpenBLAS), system ompl 1.6 for nav2
+      # (the ROS ompl 2.x is dropped below), and image gap-fillers
+      # (backward-ros, vendor helper, message-filters, ament-index-cpp).
       run: |
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           python3-vcstool python3-colcon-common-extensions \
           ros-${{ matrix.ros_distro }}-rmw-cyclonedds-cpp \
           ros-${{ matrix.ros_distro }}-tinyxml2-vendor \
-          libgdal-dev libeigen3-dev libgeos-dev libtinyxml2-dev libompl-dev
+          ros-${{ matrix.ros_distro }}-backward-ros \
+          ros-${{ matrix.ros_distro }}-ament-cmake-vendor-package \
+          ros-${{ matrix.ros_distro }}-message-filters \
+          ros-${{ matrix.ros_distro }}-ament-index-cpp \
+          libgdal-dev libeigen3-dev libgeos-dev libtinyxml2-dev libompl-dev \
+          libopenblas-dev
 
-    - name: Restore colcon cache
-      id: colcon_cache
+    - name: Restore source dependencies cache
+      id: src_cache
       uses: actions/cache/restore@v4
       with:
-        # The vcs-imported third-party sources (nav2, Fields2Cover,
-        # ortools_vendor, behaviortree_cpp) plus the colcon build/
-        # and install/ trees. These take ~1h to build from source; caching them
-        # means they build exactly once and are reused, so the ortools_vendor
-        # parallel-build race cannot recur and CI drops from ~60 min to minutes.
-        # Keyed on deps.repos, so any change to the third-party pins rebuilds all
-        # of them. Our own opennav_coverage lives outside src/deps (checked out
-        # separately) and is therefore always rebuilt against the cached deps.
-        # The container workspace path is stable across runs, so the absolute
-        # paths baked into install/ stay valid.
-        path: |
-          ros_ws/src/deps
-          ros_ws/build
-          ros_ws/install
-        key: colcon-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}
+        # Third-party sources, frozen until deps.repos changes; original
+        # mtimes let colcon skip them.
+        path: ros_ws/src/deps
+        key: srcdeps-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}
 
     - name: Import source dependencies
-      # Only on a cache miss. On a hit, src/deps is restored with its original
-      # mtimes so colcon skips the unchanged third-party packages; re-importing
-      # would reset those mtimes and force a full rebuild.
-      if: steps.colcon_cache.outputs.cache-hit != 'true'
+      # Cache miss only: re-importing resets mtimes and forces a full rebuild.
+      if: steps.src_cache.outputs.cache-hit != 'true'
       run: |
         cd ros_ws
         mkdir -p src/deps
         vcs import src/deps < src/opennav_coverage/.github/deps.repos
 
     - name: Patch nav2_common (drop -Werror)
-      # nav2 main is not -Werror-clean under Ubuntu 26.04's GCC 15 (deprecated
-      # std::atomic_load on shared_ptr, null-dereference via builtin_interfaces,
-      # ...). nav2_common applies -Werror to every nav2 package, so strip it
-      # centrally. Our own opennav packages keep their own -Werror.
-      # Skipped on a cache hit: the cached sources are already patched, and
-      # sed -i would rewrite the file (new mtime) and trigger a nav2 rebuild.
-      if: steps.colcon_cache.outputs.cache-hit != 'true'
+      # nav2 main is not -Werror-clean under GCC 15; strip it centrally.
+      # Cache miss only: cached sources are already patched.
+      if: steps.src_cache.outputs.cache-hit != 'true'
       run: sed -i 's/ -Werror//' ros_ws/src/deps/navigation2/nav2_common/cmake/nav2_package.cmake
+
+    - name: Patch nav2_map_server (missing rclcpp includes)
+      # map_io.cpp uses rclcpp logging/Clock without including any rclcpp
+      # header; current rolling no longer provides them transitively.
+      if: steps.src_cache.outputs.cache-hit != 'true'
+      run: |
+        sed -i 's|#include "nav2_map_server/map_io.hpp"|#include "rclcpp/clock.hpp"\n#include "rclcpp/logger.hpp"\n#include "rclcpp/logging.hpp"\n#include "nav2_map_server/map_io.hpp"|' \
+          ros_ws/src/deps/navigation2/nav2_map_server/src/map_io.cpp
+
+    - name: Patch ortools_vendor (gurobi/math_opt proto race)
+      # OR-Tools v9.9: ortools_gurobi includes the generated math_opt
+      # gurobi.pb.h without depending on the target that generates it, racing
+      # the codegen under parallel make. Backport the one-line v9.10 fix via
+      # the vendor's patches/ dir. Runs even on a source-cache hit (older
+      # caches predate this patch file); idempotent, fixed mtime.
+      run: |
+        p=ros_ws/src/deps/ortools_vendor/patches/0002-gurobi-mathopt-proto-dep.patch
+        [ -f "$p" ] && exit 0
+        cat > "$p" <<'EOF'
+        diff --git a/ortools/gurobi/CMakeLists.txt b/ortools/gurobi/CMakeLists.txt
+        --- a/ortools/gurobi/CMakeLists.txt
+        +++ b/ortools/gurobi/CMakeLists.txt
+        @@ -31,5 +31,6 @@
+           absl::str_format
+           protobuf::libprotobuf
+           ${PROJECT_NAMESPACE}::${PROJECT_NAME}_proto
+        +  ${PROJECT_NAMESPACE}::math_opt_proto
+           $<$<BOOL:${USE_COINOR}>:Coin::Cbc>)
+         #add_library(${PROJECT_NAMESPACE}::gurobi ALIAS ${NAME})
+        EOF
+        touch -d '2026-01-01 00:00:00 UTC' "$p"
 
     - name: Install ROS dependencies (rosdep)
       run: |
@@ -93,49 +108,102 @@ jobs:
           --rosdistro ${{ matrix.ros_distro }} -r -y || true
 
     - name: Drop shadowing apt packages
-      # Both are resolved into the shared /opt/ros/<distro> tree (by the image or
-      # by rosdep) and shadow the version nav2 main is written against, so drop
-      # them here -- after rosdep -- and let find_package fall back to the right one.
-      #
-      # behaviortree_cpp: built from source (deps.repos: master) because nav2 main
-      #   uses its unreleased wakeUpSignal() API; the Lyrical binary 4.9.0 headers
-      #   would shadow the source-built master and break nav2_behavior_tree.
-      # ompl: rosdep resolves the 'ompl' key to ros-lyrical-ompl 2.0.1, whose
-      #   ReedsShepp API differs (ReedsSheppStateSpace::ReedsSheppPath / reedsShepp()
-      #   were renamed/removed), so nav2 main's nav2_smac_planner fails to compile
-      #   against it. Removing it makes find_package(ompl) use the system
-      #   libompl-dev 1.6.0 installed above -- the API nav2 main expects, matching
-      #   the dev container.
+      # Both shadow what nav2 main is written against: binary behaviortree_cpp
+      # 4.9 lacks wakeUpSignal() (we build master from source); ROS ompl 2.x
+      # has a different ReedsShepp API than the system libompl-dev 1.6.
       run: |
         sudo apt-get remove -y ros-${{ matrix.ros_distro }}-behaviortree-cpp || true
         sudo apt-get remove -y ros-${{ matrix.ros_distro }}-ompl || true
 
+    - name: Shim removed ament_index_cpp header
+      # ament_index_cpp 1.14 removed get_package_share_directory() (header and
+      # symbol); BT.CPP master and nav2 main still include it. Forward to
+      # get_package_share_path() until they migrate. No-op when the real
+      # header exists; the fixed mtime keeps cached objects valid.
+      run: |
+        hdr=/opt/ros/${{ matrix.ros_distro }}/include/ament_index_cpp/ament_index_cpp/get_package_share_directory.hpp
+        if [ ! -f "$hdr" ]; then
+          sudo tee "$hdr" > /dev/null <<'EOF'
+        // CI compat shim for ament_index_cpp >= 1.14, which removed this header.
+        #ifndef AMENT_INDEX_CPP__GET_PACKAGE_SHARE_DIRECTORY_HPP_
+        #define AMENT_INDEX_CPP__GET_PACKAGE_SHARE_DIRECTORY_HPP_
+
+        #include <string>
+
+        #include "ament_index_cpp/get_package_share_path.hpp"
+
+        namespace ament_index_cpp
+        {
+
+        inline std::string get_package_share_directory(const std::string & package_name)
+        {
+          return get_package_share_path(package_name).string();
+        }
+
+        }  // namespace ament_index_cpp
+
+        #endif  // AMENT_INDEX_CPP__GET_PACKAGE_SHARE_DIRECTORY_HPP_
+        EOF
+          sudo touch -d '2026-01-01 00:00:00 UTC' "$hdr"
+        fi
+
+    - name: Compute environment fingerprint
+      # dpkg hash after all apt/rosdep steps. The :master image is rebuilt
+      # nightly; a build tree must only be reused in the environment it was
+      # configured in, so any drift forces one clean rebuild instead of a
+      # poisoned incremental one.
+      id: env_fp
+      run: |
+        fp=$(dpkg-query -W -f '${Package} ${Version}\n' | sha256sum | cut -c1-16)
+        echo "fp=${fp}" >> "$GITHUB_OUTPUT"
+
+    - name: Restore colcon cache
+      id: colcon_cache
+      # Keyed on deps.repos + environment fingerprint; no restore-keys (a
+      # near-miss stale tree is worse than a clean rebuild). Skipped when the
+      # source cache missed so an old tree never meets fresh sources.
+      if: steps.src_cache.outputs.cache-hit == 'true'
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ros_ws/build
+          ros_ws/install
+        key: colcon-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}-${{ steps.env_fp.outputs.fp }}
+
     - name: Build
-      # slam_toolbox is only pulled in transitively as a runtime dep of
-      # nav2_bringup (via opennav_coverage_demo); nothing here builds against it,
-      # so skip it -- no reason to build it for these tests.
+      # slam_toolbox is only a runtime dep of nav2_bringup -- skip it.
+      # One visible retry: with ~50 from-source packages transient
+      # parallel-build flakes happen; a real error fails again in minutes.
       run: |
         cd ros_ws
         . /opt/ros/${{ matrix.ros_distro }}/setup.sh
-        colcon build --packages-up-to \
-          nav2_bt_navigator nav2_behavior_tree \
-          opennav_coverage opennav_coverage_bt opennav_coverage_demo \
-          opennav_coverage_msgs opennav_coverage_navigator opennav_row_coverage \
-          --packages-skip slam_toolbox
+        build() {
+          colcon build --packages-up-to \
+            nav2_bt_navigator nav2_behavior_tree \
+            opennav_coverage opennav_coverage_bt opennav_coverage_demo \
+            opennav_coverage_msgs opennav_coverage_navigator opennav_row_coverage \
+            --packages-skip slam_toolbox
+        }
+        build || { echo "::warning::colcon build failed once; retrying to rule out a transient parallel-build flake"; build; }
+
+    - name: Save source dependencies cache
+      # Success only, so a broken upstream snapshot is never pinned.
+      if: success() && steps.src_cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ros_ws/src/deps
+        key: ${{ steps.src_cache.outputs.cache-primary-key }}
 
     - name: Save colcon cache
-      # Save only after a successful build, and only when we didn't already have
-      # a hit -- so a broken or partial build (e.g. a raced ortools_vendor) is
-      # never cached. Runs before Test so a good build is preserved even if a
-      # test later fails.
+      # Success only, before Test, so a good build survives a test failure.
+      # Key spelled out: the restore step may have been skipped.
       if: success() && steps.colcon_cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: |
-          ros_ws/src/deps
           ros_ws/build
           ros_ws/install
-        key: ${{ steps.colcon_cache.outputs.cache-primary-key }}
+        key: colcon-${{ matrix.ros_distro }}-${{ hashFiles('ros_ws/src/opennav_coverage/.github/deps.repos') }}-${{ steps.env_fp.outputs.fp }}
 
     - name: Test
       run: |

--- a/opennav_coverage/CMakeLists.txt
+++ b/opennav_coverage/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(GDAL REQUIRED)
 
 # potentially replace with nav2_common, nav2_package()
 set(CMAKE_CXX_STANDARD 20)
-add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference)
+add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC -Wshadow -Wnull-dereference -Wno-error=null-dereference)
 
 include_directories(
   include

--- a/opennav_coverage/include/opennav_coverage/types.hpp
+++ b/opennav_coverage/include/opennav_coverage/types.hpp
@@ -61,7 +61,8 @@ enum class SwathType
   UNKNOWN = 0,
   LENGTH = 1,
   NUMBER = 2,
-  COVERAGE = 3
+  COVERAGE = 3,
+  NUMBER_MODIFIED = 4
 };
 
 /**

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -204,15 +204,21 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
  * @param Field Field to use for conversion from UTM if necessary
  * @param header header
  * @param bool if the origional CRS is cartesian or not requiring conversion
+ * @param out_velocities Optional: if non-null, filled with per-pose velocity (m/s), parallel to poses
+ * @param out_is_backward Optional: if non-null, filled with per-pose reverse-direction flags
  * @return nav_msgs/Path Path
  */
 inline nav_msgs::msg::Path toNavPathMsg(
   const Path & raw_path, const F2CField & field,
   const std_msgs::msg::Header & header, const bool is_cartesian,
-  const float & pt_dist)
+  const float & pt_dist,
+  std::vector<double> * out_velocities = nullptr,
+  std::vector<bool> * out_is_backward = nullptr)
 {
   nav_msgs::msg::Path msg;
   msg.header = header;
+  if (out_velocities) {out_velocities->clear();}
+  if (out_is_backward) {out_is_backward->clear();}
 
   if (raw_path.size() == 0) {
     return msg;
@@ -228,9 +234,18 @@ inline nav_msgs::msg::Path toNavPathMsg(
   // discretizeSwath splits only SWATH states at pt_dist intervals, leaving dense turns intact.
   path = path.discretizeSwath(static_cast<double>(pt_dist));
 
-  msg.poses.reserve(path.size());
+  // Reserve up front so the population loop below doesn't reallocate.
+  const auto n = path.size();
+  msg.poses.reserve(n);
+  if (out_velocities) {out_velocities->reserve(n);}
+  if (out_is_backward) {out_is_backward->reserve(n);}
+
   for (const auto & state : path) {
     msg.poses.push_back(toMsg(state));
+    if (out_velocities) {out_velocities->push_back(state.velocity);}
+    if (out_is_backward) {
+      out_is_backward->push_back(state.dir == f2c::types::PathDirection::BACKWARD);
+    }
   }
 
   return msg;

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
+
 #include "opennav_coverage/coverage_server.hpp"
 
 using namespace std::chrono_literals;
@@ -210,6 +212,8 @@ void CoverageServer::computeCoveragePath()
         result->nav_path = util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
           &result->coverage_path.velocities, &result->coverage_path.is_backward);
+        const double task_time = path.getTaskTime();
+        result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {
         result->coverage_path =
           util::toCoveragePathMsg(route, master_field, true, header, cartesian_frame_);

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -208,7 +208,8 @@ void CoverageServer::computeCoveragePath()
         result->coverage_path =
           util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = util::toNavPathMsg(
-          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance());
+          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
+          &result->coverage_path.velocities, &result->coverage_path.is_backward);
       } else {
         result->coverage_path =
           util::toCoveragePathMsg(route, master_field, true, header, cartesian_frame_);

--- a/opennav_coverage/src/swath_generator.cpp
+++ b/opennav_coverage/src/swath_generator.cpp
@@ -80,6 +80,8 @@ SwathObjectivePtr SwathGenerator::createObjective(const SwathType & type)
       return std::move(std::make_shared<f2c::obj::NSwath>());
     case SwathType::COVERAGE:
       return std::move(std::make_shared<f2c::obj::FieldCoverage>());
+    case SwathType::NUMBER_MODIFIED:
+      return std::move(std::make_shared<f2c::obj::NSwathModified>());
     default:
       RCLCPP_WARN(logger_, "Unknown swath type set!");
       return SwathObjectivePtr{nullptr};
@@ -98,6 +100,9 @@ std::string SwathGenerator::toString(const SwathType & type, const SwathAngleTyp
       break;
     case SwathType::COVERAGE:
       str = "Coverage";
+      break;
+    case SwathType::NUMBER_MODIFIED:
+      str = "Number Modified";
       break;
     default:
       str = "Unknown";
@@ -132,6 +137,8 @@ SwathType SwathGenerator::toType(const std::string & str)
     return SwathType::NUMBER;
   } else if (mode_str == "COVERAGE") {
     return SwathType::COVERAGE;
+  } else if (mode_str == "NUMBER_MODIFIED") {
+    return SwathType::NUMBER_MODIFIED;
   } else {
     return SwathType::UNKNOWN;
   }

--- a/opennav_coverage/test/test_swath.cpp
+++ b/opennav_coverage/test/test_swath.cpp
@@ -81,16 +81,23 @@ TEST(SwathTests, TestswathUtils)
   EXPECT_EQ(generator.toTypeShim("number"), SwathType::NUMBER);
   EXPECT_EQ(generator.toTypeShim("COVERAGE"), SwathType::COVERAGE);
   EXPECT_EQ(generator.toTypeShim("coverage"), SwathType::COVERAGE);
-
+  EXPECT_EQ(generator.toTypeShim("NUMBER_MODIFIED"), SwathType::NUMBER_MODIFIED);
+  EXPECT_EQ(generator.toTypeShim("number_modified"), SwathType::NUMBER_MODIFIED);
 
   EXPECT_EQ(generator.toStringShim(SwathType::NUMBER, SwathAngleType::SET_ANGLE).size(), 37u);
   EXPECT_EQ(generator.toStringShim(SwathType::COVERAGE, SwathAngleType::BRUTE_FORCE).size(), 41u);
   EXPECT_GT(generator.toStringShim(SwathType::UNKNOWN, SwathAngleType::UNKNOWN).size(), 20u);
   EXPECT_GT(generator.toStringShim(SwathType::UNKNOWN, SwathAngleType::BRUTE_FORCE).size(), 20u);
 
+  EXPECT_EQ(
+    generator.toStringShim(SwathType::NUMBER_MODIFIED, SwathAngleType::BRUTE_FORCE).size(), 48u);
+  EXPECT_EQ(
+    generator.toStringShim(SwathType::NUMBER_MODIFIED, SwathAngleType::SET_ANGLE).size(), 46u);
+
   EXPECT_TRUE(generator.createObjectiveShim(SwathType::LENGTH));
   EXPECT_TRUE(generator.createObjectiveShim(SwathType::NUMBER));
   EXPECT_TRUE(generator.createObjectiveShim(SwathType::COVERAGE));
+  EXPECT_TRUE(generator.createObjectiveShim(SwathType::NUMBER_MODIFIED));
   EXPECT_FALSE(generator.createObjectiveShim(SwathType::UNKNOWN));
 
   generator.setSwathAngleMode("NUMBER");
@@ -119,6 +126,9 @@ TEST(SwathTests, TestswathGeneration)
   settings.mode = "SET_ANGLE";
   settings.objective = "NUMBER";
   auto swaths3 = generator.generateSwaths(field.getField().getGeometry(0), settings);
+  settings.mode = "BRUTE_FORCE";
+  settings.objective = "NUMBER_MODIFIED";
+  auto swaths4 = generator.generateSwaths(field.getField().getGeometry(0), settings);
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -253,4 +253,119 @@ TEST(UtilsTests, TestPathComponentsIterator)
   EXPECT_EQ(std::get<1>(last_row_info), nullptr);
 }
 
+// B.6-T2: empty path → velocity and is_backward vectors are empty
+TEST(UtilsTests, TesttoNavPathMsgEmptyVelocity)
+{
+  std_msgs::msg::Header header_in;
+  Path empty_path;
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+
+  auto nav_path = util::toNavPathMsg(empty_path, field, header_in, true, 0.1f, &vels, &dirs);
+  EXPECT_TRUE(nav_path.poses.empty());
+  EXPECT_TRUE(vels.empty());
+  EXPECT_TRUE(dirs.empty());
+}
+
+// B.6-T3: forward-only path → all is_backward entries are false
+TEST(UtilsTests, TesttoNavPathMsgForwardOnly)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+  PathState s;
+  s.type = f2c::types::PathSectionType::SWATH;
+  s.point = Point(0.0, 0.0);
+  s.len = 1.0;
+  s.angle = 0.0;
+  s.velocity = 1.5;
+  s.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(s);
+  F2CField field;
+
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  for (const auto & d : dirs) {
+    EXPECT_FALSE(d);
+  }
+  for (const auto & v : vels) {
+    EXPECT_NEAR(v, 1.5, 1e-6);
+  }
+}
+
+// B.6-T1: velocity and is_backward values match PathState fields after discretizeSwath
+TEST(UtilsTests, TesttoNavPathMsgWithVelocity)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState swath;
+  swath.type = f2c::types::PathSectionType::SWATH;
+  swath.point = Point(0.0, 0.0);
+  swath.len = 1.0;
+  swath.angle = 0.0;
+  swath.velocity = 2.0;
+  swath.dir = f2c::types::PathDirection::BACKWARD;
+  path_in.addState(swath);
+
+  PathState turn;
+  turn.type = f2c::types::PathSectionType::TURN;
+  turn.velocity = 0.5;
+  turn.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(turn);
+
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  // SWATH states: velocity=2.0, direction=BACKWARD
+  EXPECT_NEAR(vels[0], 2.0, 1e-6);
+  EXPECT_TRUE(dirs[0]);
+  // TURN state: velocity=0.5, direction=FORWARD
+  EXPECT_NEAR(vels.back(), 0.5, 1e-6);
+  EXPECT_FALSE(dirs.back());
+}
+
+// B.6+B.7 integration: poses, velocities, is_backward sizes must match after discretizeSwath
+TEST(UtilsTests, TesttoNavPathMsgDensifyVelocitySizeMatch)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState swath;
+  swath.type = f2c::types::PathSectionType::SWATH;
+  swath.len = 1.0;
+  swath.velocity = 1.5;
+  swath.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(swath);
+
+  PathState turn;
+  turn.type = f2c::types::PathSectionType::TURN;
+  turn.velocity = 0.5;
+  turn.dir = f2c::types::PathDirection::BACKWARD;
+  path_in.addState(turn);
+  path_in.addState(turn);
+
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  // SWATH poses are forward; TURN poses are backward
+  EXPECT_FALSE(dirs[0]);
+  EXPECT_TRUE(dirs.back());
+}
+
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <utility>
 
 #include "gtest/gtest.h"
@@ -209,6 +210,71 @@ TEST(UtilsTests, TestgetFieldFromGoal)
   goal->polygons[1].coordinates[0].axis1 = 1.0;
   auto field2 = util::getFieldFromGoal(goal);
   EXPECT_EQ(field2.getField().getGeometry(0).getGeometry(1).size(), 3u);
+}
+
+TEST(UtilsTests, TesttoNavPathMsgDiscreteSwathPointCount)
+{
+  // A single SWATH state with len=1.0 at step=0.1 → n_steps = round(1.0/0.1) = 10
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+  PathState s;
+  s.type = f2c::types::PathSectionType::SWATH;
+  s.point = Point(0.0, 0.0);
+  s.len = 1.0;
+  s.angle = 0.0;
+  path_in.addState(s);
+  F2CField field;
+
+  auto msg = util::toNavPathMsg(path_in, field, header_in, true, 0.1f);
+  EXPECT_EQ(msg.poses.size(), 10u);
+}
+
+TEST(UtilsTests, TesttoNavPathMsgTurnUnchanged)
+{
+  // TURN states must pass through discretizeSwath unmodified (regression guard)
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+  path_in.getStates().resize(10);
+  for (auto & state : path_in.getStates()) {
+    state.type = f2c::types::PathSectionType::TURN;
+  }
+  F2CField field;
+
+  auto msg = util::toNavPathMsg(path_in, field, header_in, true, 0.1f);
+  EXPECT_EQ(msg.poses.size(), 10u);
+}
+
+TEST(UtilsTests, TestGetTaskTime)
+{
+  Path path;
+  PathState s;
+  s.len = 5.0;
+  s.velocity = 2.0;
+  path.addState(s);
+
+  EXPECT_NEAR(path.getTaskTime(), 2.5, 0.01);
+}
+
+TEST(UtilsTests, TestGetTaskTimeZeroVelocity)
+{
+  // velocity=0 → getTaskTime() returns inf; caller must guard with std::isfinite
+  Path path;
+  PathState s;
+  s.len = 1.0;
+  s.velocity = 0.0;
+  path.addState(s);
+
+  EXPECT_FALSE(std::isfinite(path.getTaskTime()));
+  const double guarded = std::isfinite(path.getTaskTime()) ? path.getTaskTime() : 0.0;
+  EXPECT_NEAR(guarded, 0.0, 1e-9);
+}
+
+TEST(UtilsTests, TestGetTaskTimeEmptyPath)
+{
+  Path empty;
+  EXPECT_NEAR(empty.getTaskTime(), 0.0, 1e-9);
 }
 
 TEST(UtilsTests, TestPathComponentsIterator)

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -35,6 +35,7 @@ uint16 INVALID_COORDS=803
 nav_msgs/Path nav_path
 opennav_coverage_msgs/PathComponents coverage_path
 builtin_interfaces/Duration planning_time
+float64 task_time
 uint16 error_code
 
 ---

--- a/opennav_coverage_msgs/msg/PathComponents.msg
+++ b/opennav_coverage_msgs/msg/PathComponents.msg
@@ -4,3 +4,8 @@ opennav_coverage_msgs/Swath[] swaths
 nav_msgs/Path[] turns
 bool contains_turns
 bool swaths_ordered
+
+# Per-pose velocity (m/s) and direction flags, parallel to nav_path.poses.
+# Populated only when generate_path=true. Empty when path is not generated.
+float64[] velocities
+bool[] is_backward

--- a/opennav_coverage_msgs/msg/SwathMode.msg
+++ b/opennav_coverage_msgs/msg/SwathMode.msg
@@ -1,4 +1,4 @@
-string objective "UNKNOWN"  # LENGTH, NUMBER, or COVERAGE
+string objective "UNKNOWN"  # LENGTH, NUMBER, NUMBER_MODIFIED, or COVERAGE
 string mode "UNKNOWN"  # BRUTE_FORCE, SET_ANGLE
 
 # Specific mode settings

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -206,7 +206,8 @@ void RowCoverageServer::computeCoveragePath()
         result->coverage_path =
           opennav_coverage::util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = opennav_coverage::util::toNavPathMsg(
-          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance());
+          path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
+          &result->coverage_path.velocities, &result->coverage_path.is_backward);
       } else {
         result->coverage_path =
           opennav_coverage::util::toCoveragePathMsg(

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
+
 #include "opennav_row_coverage/row_coverage_server.hpp"
 
 using namespace std::chrono_literals;
@@ -208,6 +210,8 @@ void RowCoverageServer::computeCoveragePath()
         result->nav_path = opennav_coverage::util::toNavPathMsg(
           path, master_field, header, cartesian_frame_, path_gen_->getTurnPointDistance(),
           &result->coverage_path.velocities, &result->coverage_path.is_backward);
+        const double task_time = path.getTaskTime();
+        result->task_time = std::isfinite(task_time) ? task_time : 0.0;
       } else {
         result->coverage_path =
           opennav_coverage::util::toCoveragePathMsg(


### PR DESCRIPTION
## Summary

It bundles three small, self-contained output/objective improvements plus one
build fix, and brings the Lyrical CI workflow up to the current rolling/`main`
pipeline.

This is the Lyrical counterpart of #112 (which targeted the rolling/`main`
branch). The changes are the same, adapted to Lyrical:
- The `discretizeSwath` swath refactor from #112 already landed on Lyrical via
  the Fields2Cover v2 migration (#116), so here `toNavPathMsg` only *gains* the
  per-pose velocity/direction population on top of it.

## Changes

**1. Per-pose velocity and direction on `PathComponents`**
**2. Task time on the action result**
**3. `NUMBER_MODIFIED` swath objective**
**4. Build fix: keep `-Wnull-dereference` non-fatal**

## CI

Lyrical uses the same resolute / build-from-source pipeline as rolling, so this
also ports the rolling/`main` CI overhaul from #113 to the Lyrical workflow,
keeping the Lyrical image, `ros_distro` and setup paths:

- Split the colcon cache in two (frozen third-party sources vs `build`/`install`),
  keying the latter on a post-install dpkg fingerprint so a nightly-rebuilt image
  forces one clean rebuild instead of a poisoned incremental one.
- Add source patches applied between `vcs import` and build: `nav2_map_server`
  missing `rclcpp` includes, and the `ortools_vendor` gurobi/math_opt proto race.
- Shim the `get_package_share_directory` header removed by `ament_index_cpp` 1.14,
  which BT.CPP master and nav2 main still include.
- Install the extra build deps rosdep can't reliably resolve on resolute
  (`backward-ros`, `ament-cmake-vendor-package`, `message-filters`,
  `ament-index-cpp`, OpenBLAS), and add one visible build retry for transient
  parallel-build flakes.

## Interface changes (all additive)

- `PathComponents.msg`: `+ float64[] velocities`, `+ bool[] is_backward`
- `ComputeCoveragePath.action` (result): `+ float64 task_time`
- `SwathMode.msg`: `objective` now also accepts `NUMBER_MODIFIED` (doc comment updated)
