### PR TITLE
Add field decomposition (trapezoidal / boustrophedon) with HL_SWATH handling (jazzy)

### DIFF
--- a/opennav_coverage/CMakeLists.txt
+++ b/opennav_coverage/CMakeLists.txt
@@ -49,6 +49,7 @@ set(dependencies
 
 add_library(${library_name} SHARED
   src/coverage_server.cpp
+  src/decomp_generator.cpp
   src/headland_generator.cpp
   src/swath_generator.cpp
   src/route_generator.cpp

--- a/opennav_coverage/include/opennav_coverage/coverage_server.hpp
+++ b/opennav_coverage/include/opennav_coverage/coverage_server.hpp
@@ -24,6 +24,7 @@
 #include "nav2_util/lifecycle_node.hpp"
 #include "nav2_util/node_utils.hpp"
 #include "nav2_util/simple_action_server.hpp"
+#include "opennav_coverage/decomp_generator.hpp"
 #include "opennav_coverage/headland_generator.hpp"
 #include "opennav_coverage/swath_generator.hpp"
 #include "opennav_coverage/route_generator.hpp"
@@ -123,12 +124,14 @@ protected:
   std::unique_ptr<ActionServer> action_server_;
 
   std::unique_ptr<RobotParams> robot_params_;
+  std::unique_ptr<DecompGenerator> decomp_gen_;
   std::unique_ptr<HeadlandGenerator> headland_gen_;
   std::unique_ptr<SwathGenerator> swath_gen_;
   std::unique_ptr<RouteGenerator> route_gen_;
   std::unique_ptr<PathGenerator> path_gen_;
   std::unique_ptr<Visualizer> visualizer_;
   bool cartesian_frame_;
+  bool default_generate_decomp_{false};
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/include/opennav_coverage/decomp_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/decomp_generator.hpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef OPENNAV_COVERAGE__DECOMP_GENERATOR_HPP_
+#define OPENNAV_COVERAGE__DECOMP_GENERATOR_HPP_
+
+#include <string>
+
+#include "fields2cover.h" // NOLINT
+
+#include "rclcpp/rclcpp.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/node_utils.hpp"
+#include "opennav_coverage_msgs/msg/decomp_mode.hpp"
+#include "opennav_coverage/utils.hpp"
+#include "opennav_coverage/types.hpp"
+
+namespace opennav_coverage
+{
+
+/**
+ * @class Decomposition mode and state
+ */
+class DecompGenerator
+{
+public:
+  /**
+   * @brief Constructor for Decomposition mode
+   * @param node A node to get the Decomposition type from
+   */
+  template<typename NodeT>
+  explicit DecompGenerator(const NodeT & node)
+  {
+    logger_ = node->get_logger();
+
+    nav2_util::declare_parameter_if_not_declared(
+      node, "default_decomp_type", rclcpp::ParameterValue("NONE"));
+    std::string type_str = node->get_parameter("default_decomp_type").as_string();
+    default_type_ = toType(type_str);
+
+    nav2_util::declare_parameter_if_not_declared(
+      node, "default_decomp_split_angle", rclcpp::ParameterValue(0.0));
+    default_split_angle_ = node->get_parameter("default_decomp_split_angle").as_double();
+  }
+
+  /**
+   * @brief Main method to decompose a field into simpler sub-cells
+   * @param cells Cells to decompose
+   * @param settings Action request information
+   * @return Decomposed cells (may be a single cell if NONE)
+   */
+  F2CCells decompose(
+    const F2CCells & cells,
+    const opennav_coverage_msgs::msg::DecompMode & settings);
+
+  /**
+   * @brief Sets the mode manually of the Decomposition for dynamic parameters
+   * @param new_mode String for mode to use
+   */
+  void setMode(const std::string & new_mode);
+
+  /**
+   * @brief Sets the split angle manually for dynamic parameters
+   * @param angle Split angle in radians
+   */
+  void setSplitAngle(double angle) {default_split_angle_ = angle;}
+
+protected:
+  /**
+   * @brief Converts the Decomposition mode into a string for publication
+   * @param type Type of mode
+   * @return String of mode
+   */
+  std::string toString(const DecompType & type);
+
+  /**
+   * @brief Converts the Decomposition string into a mode for handling
+   * @param str String of mode
+   * @return Type of mode
+   */
+  DecompType toType(const std::string & str);
+
+  DecompType default_type_;
+  double default_split_angle_;
+  rclcpp::Logger logger_{rclcpp::get_logger("DecompGenerator")};
+};
+
+}  // namespace opennav_coverage
+
+#endif  // OPENNAV_COVERAGE__DECOMP_GENERATOR_HPP_

--- a/opennav_coverage/include/opennav_coverage/headland_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/headland_generator.hpp
@@ -65,6 +65,15 @@ public:
     const Field & field, const opennav_coverage_msgs::msg::HeadlandMode & settings);
 
   /**
+   * @brief Multi-cell overload: apply a separate headland to each sub-cell
+   * @param cells Cells to generate headlands from
+   * @param settings Action request information
+   * @return Cells with headlands applied per sub-cell
+   */
+  F2CCells generateHeadlands(
+    const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings);
+
+  /**
    * @brief Sets the mode manually of the Headland for dynamic parameters
    * @param mode String for mode to use
    */

--- a/opennav_coverage/include/opennav_coverage/swath_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/swath_generator.hpp
@@ -85,6 +85,15 @@ public:
     const Field & field, const opennav_coverage_msgs::msg::SwathMode & settings);
 
   /**
+   * @brief Multi-cell overload: generate swaths across decomposed cells
+   * @param cells Cells to generate swaths from
+   * @param settings Action request information
+   * @return Flattened swaths across all cells
+   */
+  Swaths generateSwaths(
+    const F2CCells & cells, const opennav_coverage_msgs::msg::SwathMode & settings);
+
+  /**
    * @brief Sets the mode manually of the swath for dynamic parameters
    * @param mode String for mode to use
    */
@@ -109,12 +118,31 @@ public:
   void setOVerlap(const bool & setting) {default_allow_overlap_ = setting;}
 
   /**
-   * @brief Sets default search step for brute force for dynamic parameters
-   * @param mode String for mode to use
+   * @brief Sets default search step angle for brute force for dynamic parameters
+   * @param setting Step angle in radians
    */
-  void setStepAngle(const bool & setting) {default_step_angle_ = setting;}
+  void setStepAngle(const double & setting) {default_step_angle_ = setting;}
 
 protected:
+  /**
+   * @struct Resolved swath parameters shared by the single- and multi-cell paths
+   */
+  struct ResolvedSwathParams
+  {
+    SwathObjectivePtr objective;
+    SwathAngleType angle_type;
+    float swath_angle;
+    float step_angle;
+  };
+
+  /**
+   * @brief Resolves action-vs-default swath parameters (shared logic)
+   * @param settings Action request information
+   * @return Resolved parameters
+   */
+  ResolvedSwathParams resolveSwathParams(
+    const opennav_coverage_msgs::msg::SwathMode & settings);
+
   /**
    * @brief Creates objective pointer of a requested type
    * @param type Swaths generator type to create

--- a/opennav_coverage/include/opennav_coverage/types.hpp
+++ b/opennav_coverage/include/opennav_coverage/types.hpp
@@ -107,6 +107,17 @@ enum class PathContinuityType
   DISCONTINUOUS = 2
 };
 
+/**
+ * @enum Decomposition types
+ */
+enum class DecompType
+{
+  UNKNOWN = 0,
+  NONE = 1,
+  TRAPEZOIDAL = 2,
+  BOUSTROPHEDON = 3
+};
+
 class CoverageException : public std::runtime_error
 {
 public:

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -142,8 +142,14 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
     path.moveTo(field.getRefPoint());
   }
 
+  // Decomposition produces HL_SWATH states for inter-cell headland passes;
+  // treat them like regular SWATH states.
+  auto isSwathLike = [](PathSectionType t) {
+      return t == PathSectionType::SWATH || t == PathSectionType::HL_SWATH;
+    };
+
   PathSectionType curr_state = path[0].type;
-  if (curr_state == PathSectionType::SWATH) {
+  if (isSwathLike(curr_state)) {
     curr_swath_start = path[0].point;
   } else if (curr_state == PathSectionType::TURN) {
     msg.turns.push_back(nav_msgs::msg::Path());
@@ -152,14 +158,19 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
   }
 
   for (unsigned int i = 0; i != path.size(); i++) {
-    if (curr_state == path[i].type && path[i].type == PathSectionType::SWATH) {
-      // Continuing swath so...
+    const bool prev_swath = isSwathLike(curr_state);
+    const bool prev_turn = curr_state == PathSectionType::TURN;
+    const bool now_swath = isSwathLike(path[i].type);
+    const bool now_turn = path[i].type == PathSectionType::TURN;
+
+    if (prev_swath && now_swath) {
+      // Continuing swath (SWATH or HL_SWATH) so...
       // (1) no action required.
-    } else if (curr_state == path[i].type && path[i].type == PathSectionType::TURN) {
+    } else if (prev_turn && now_turn) {
       // Continuing a turn so...
       // (1) keep populating
       curr_turn->poses.push_back(toMsg(path[i]));
-    } else if (curr_state != path[i].type && path[i].type == PathSectionType::TURN) {
+    } else if (prev_swath && now_turn) {
       // Transitioning from a swath to a turn so...
       // (1) Complete the existing swath
       opennav_coverage_msgs::msg::Swath swath;
@@ -171,7 +182,7 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
       msg.turns.back().header = header;
       curr_turn = &msg.turns.back();
       curr_turn->poses.push_back(toMsg(path[i]));
-    } else if (curr_state != path[i].type && path[i].type == PathSectionType::SWATH) {
+    } else if (prev_turn && now_swath) {
       // Transitioning from a turn to a swath so...
       // (1) Update new swath starting point
       curr_swath_start = path[i].point;
@@ -179,14 +190,14 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
 
     curr_state = path[i].type;
 
-    if (path[i].type != PathSectionType::SWATH &&
+    if (!isSwathLike(path[i].type) &&
       path[i].type != PathSectionType::TURN)
     {
       throw std::runtime_error("Unknown type of path state detected, cannot obtain path!");
     }
   }
 
-  if (curr_state == PathSectionType::SWATH) {
+  if (isSwathLike(curr_state)) {
     opennav_coverage_msgs::msg::Swath swath;
     swath.start = toMsg(curr_swath_start);
     swath.end = toMsg(path.back().point);

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -36,11 +36,16 @@ CoverageServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
   auto node = shared_from_this();
 
   robot_params_ = std::make_unique<RobotParams>(node);
+  decomp_gen_ = std::make_unique<DecompGenerator>(node);
   headland_gen_ = std::make_unique<HeadlandGenerator>(node);
   swath_gen_ = std::make_unique<SwathGenerator>(node, robot_params_.get());
   route_gen_ = std::make_unique<RouteGenerator>(node);
   path_gen_ = std::make_unique<PathGenerator>(node, robot_params_.get());
   visualizer_ = std::make_unique<Visualizer>();
+
+  nav2_util::declare_parameter_if_not_declared(
+    node, "default_generate_decomp", rclcpp::ParameterValue(false));
+  get_parameter("default_generate_decomp", default_generate_decomp_);
 
   // If in GPS coordinates, we must convert to a CRS to compute coverage
   // Then, reconvert back to GPS for the user.
@@ -109,6 +114,7 @@ CoverageServer::on_cleanup(const rclcpp_lifecycle::State & /*state*/)
   route_gen_.reset();
   swath_gen_.reset();
   headland_gen_.reset();
+  decomp_gen_.reset();
   robot_params_.reset();
   return nav2_util::CallbackReturn::SUCCESS;
 }
@@ -194,14 +200,31 @@ void CoverageServer::computeCoveragePath()
       "Generating coverage path in %s frame for zone with %zu outer nodes and %zu inner polygons.",
       frame_id.c_str(), field.getGeometry(0).size(), field.size() - 1);
 
-    // (1) Optional: Remove headland from polygon field
-    Field field_no_headland = field;
-    if (goal->generate_headland) {
-      field_no_headland = headland_gen_->generateHeadlands(field, goal->headland_mode);
-    }
+    // (1) Optional: decompose non-convex field, then remove headland, then generate swaths
+    const bool do_decomp = goal->generate_decomp || default_generate_decomp_;
 
-    // (2) Generate swaths to cover polygon field, including internal voids
-    Swaths swaths = swath_gen_->generateSwaths(field_no_headland, goal->swath_mode);
+    Field field_no_headland = field;
+    Swaths swaths;
+    if (do_decomp) {
+      F2CCells raw_cells;
+      raw_cells.addGeometry(field);
+      F2CCells decomposed = decomp_gen_->decompose(raw_cells, goal->decomp_mode);
+
+      // Apply a separate headland to each sub-cell
+      F2CCells cells_no_headland = decomposed;
+      if (goal->generate_headland) {
+        cells_no_headland = headland_gen_->generateHeadlands(decomposed, goal->headland_mode);
+      }
+      swaths = swath_gen_->generateSwaths(cells_no_headland, goal->swath_mode);
+    } else {
+      // (1) Optional: Remove headland from polygon field
+      if (goal->generate_headland) {
+        field_no_headland = headland_gen_->generateHeadlands(field, goal->headland_mode);
+      }
+
+      // (2) Generate swaths to cover polygon field, including internal voids
+      swaths = swath_gen_->generateSwaths(field_no_headland, goal->swath_mode);
+    }
 
     // (3) Optional: Generate an ordered route through the unordered swaths
     std_msgs::msg::Header header;

--- a/opennav_coverage/src/decomp_generator.cpp
+++ b/opennav_coverage/src/decomp_generator.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+#include <string>
+
+#include "opennav_coverage/decomp_generator.hpp"
+
+namespace opennav_coverage
+{
+
+F2CCells DecompGenerator::decompose(
+  const F2CCells & cells,
+  const opennav_coverage_msgs::msg::DecompMode & settings)
+{
+  // "UNKNOWN" -> use default_type_ (same pattern as Headland/Swath generators)
+  DecompType type = toType(settings.mode);
+  if (type == DecompType::UNKNOWN) {
+    type = default_type_;
+  }
+
+  double split_angle =
+    std::abs(settings.split_angle) < 1e-9 ?
+    default_split_angle_ : settings.split_angle;
+
+  if (type == DecompType::NONE) {
+    return cells;  // no-op
+  }
+
+  RCLCPP_DEBUG(
+    logger_, "Decomposing field with type %s, split_angle=%.3f",
+    toString(type).c_str(), split_angle);
+
+  if (type == DecompType::TRAPEZOIDAL) {
+    f2c::decomp::TrapezoidalDecomp decomp;
+    decomp.setSplitAngle(split_angle);
+    return decomp.decompose(cells);
+  } else if (type == DecompType::BOUSTROPHEDON) {
+    f2c::decomp::BoustrophedonDecomp decomp;
+    decomp.setSplitAngle(split_angle);
+    return decomp.decompose(cells);
+  }
+
+  throw CoverageException("Unknown decomp type requested!");
+}
+
+std::string DecompGenerator::toString(const DecompType & type)
+{
+  switch (type) {
+    case DecompType::NONE: return "NONE";
+    case DecompType::TRAPEZOIDAL: return "TRAPEZOIDAL";
+    case DecompType::BOUSTROPHEDON: return "BOUSTROPHEDON";
+    default: return "UNKNOWN";
+  }
+}
+
+DecompType DecompGenerator::toType(const std::string & str)
+{
+  std::string upper = str;
+  util::toUpper(upper);
+  if (upper == "NONE") {
+    return DecompType::NONE;
+  }
+  if (upper == "TRAPEZOIDAL") {
+    return DecompType::TRAPEZOIDAL;
+  }
+  if (upper == "BOUSTROPHEDON") {
+    return DecompType::BOUSTROPHEDON;
+  }
+  return DecompType::UNKNOWN;  // left to caller (falls back to default)
+}
+
+void DecompGenerator::setMode(const std::string & new_mode)
+{
+  default_type_ = toType(new_mode);
+}
+
+}  // namespace opennav_coverage

--- a/opennav_coverage/src/headland_generator.cpp
+++ b/opennav_coverage/src/headland_generator.cpp
@@ -46,6 +46,16 @@ Field HeadlandGenerator::generateHeadlands(
   return generator->generateHeadlands(Fields(field), width).getGeometry(0);
 }
 
+F2CCells HeadlandGenerator::generateHeadlands(
+  const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings)
+{
+  F2CCells result;
+  for (size_t i = 0; i < cells.size(); ++i) {
+    result.addGeometry(generateHeadlands(cells.getGeometry(i), settings));
+  }
+  return result;
+}
+
 void HeadlandGenerator::setMode(const std::string & new_mode)
 {
   default_type_ = toType(new_mode);

--- a/opennav_coverage/src/swath_generator.cpp
+++ b/opennav_coverage/src/swath_generator.cpp
@@ -20,41 +20,74 @@
 namespace opennav_coverage
 {
 
-Swaths SwathGenerator::generateSwaths(
-  const Field & field, const opennav_coverage_msgs::msg::SwathMode & settings)
+SwathGenerator::ResolvedSwathParams SwathGenerator::resolveSwathParams(
+  const opennav_coverage_msgs::msg::SwathMode & settings)
 {
   SwathType action_type = toType(settings.objective);
   SwathAngleType action_angle_type = toAngleType(settings.mode);
-  SwathObjectivePtr objective{nullptr};
-  float swath_angle = 0.0f;
-  float step_angle = 0.0f;
+  ResolvedSwathParams p;
 
   // If not set by action, use default mode
   if (action_type == SwathType::UNKNOWN && action_angle_type == SwathAngleType::UNKNOWN) {
     action_type = default_type_;
-    action_angle_type = default_angle_type_;
-    objective = default_objective_;
-    swath_angle = default_swath_angle_;
-    step_angle = default_step_angle_;
+    p.angle_type = default_angle_type_;
+    p.objective = default_objective_;
+    p.swath_angle = default_swath_angle_;
+    p.step_angle = default_step_angle_;
   } else {
-    objective = createObjective(action_type);
-    swath_angle = settings.best_angle;
-    step_angle = settings.step_angle;
+    p.angle_type = action_angle_type;
+    p.objective = createObjective(action_type);
+    p.swath_angle = settings.best_angle;
+    p.step_angle = settings.step_angle;
   }
 
   RCLCPP_DEBUG(
-    logger_, "Generating Swaths with: %s", toString(action_type, action_angle_type).c_str());
+    logger_, "Generating Swaths with: %s", toString(action_type, p.angle_type).c_str());
+  return p;
+}
 
+Swaths SwathGenerator::generateSwaths(
+  const Field & field, const opennav_coverage_msgs::msg::SwathMode & settings)
+{
+  ResolvedSwathParams p = resolveSwathParams(settings);
+  const double op_width = robot_params_->getOperationWidth();
   generator_->setAllowOverlap(default_allow_overlap_);
-  switch (action_angle_type) {
+  switch (p.angle_type) {
     case SwathAngleType::BRUTE_FORCE:
-      if (!objective) {
-        throw CoverageException("No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE.");
+      if (!p.objective) {
+        throw CoverageException(
+                "No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE, NUMBER_MODIFIED.");
       }
-      generator_->setStepAngle(step_angle);
-      return generator_->generateBestSwaths(*objective, robot_params_->getOperationWidth(), field);
+      generator_->setStepAngle(p.step_angle);
+      return generator_->generateBestSwaths(*p.objective, op_width, field);
     case SwathAngleType::SET_ANGLE:
-      return generator_->generateSwaths(swath_angle, robot_params_->getOperationWidth(), field);
+      return generator_->generateSwaths(p.swath_angle, op_width, field);
+    default:
+      throw CoverageException("No valid swath angle mode set! Options: BRUTE_FORCE, SET_ANGLE.");
+  }
+}
+
+Swaths SwathGenerator::generateSwaths(
+  const F2CCells & cells, const opennav_coverage_msgs::msg::SwathMode & settings)
+{
+  // Single cell -> use the existing Field path (no flatten needed)
+  if (cells.size() == 1) {
+    return generateSwaths(cells.getGeometry(0), settings);
+  }
+
+  ResolvedSwathParams p = resolveSwathParams(settings);
+  const double op_width = robot_params_->getOperationWidth();
+  generator_->setAllowOverlap(default_allow_overlap_);
+  switch (p.angle_type) {
+    case SwathAngleType::BRUTE_FORCE:
+      if (!p.objective) {
+        throw CoverageException(
+                "No valid swath mode set! Options: LENGTH, NUMBER, COVERAGE, NUMBER_MODIFIED.");
+      }
+      generator_->setStepAngle(p.step_angle);
+      return generator_->generateBestSwaths(*p.objective, op_width, cells).flatten();
+    case SwathAngleType::SET_ANGLE:
+      return generator_->generateSwaths(p.swath_angle, op_width, cells).flatten();
     default:
       throw CoverageException("No valid swath angle mode set! Options: BRUTE_FORCE, SET_ANGLE.");
   }

--- a/opennav_coverage/test/CMakeLists.txt
+++ b/opennav_coverage/test/CMakeLists.txt
@@ -31,6 +31,14 @@ target_link_libraries(test_viz
   ${library_name}
 )
 
+# Test decomp
+ament_add_gtest(test_decomp_generator
+  test_decomp_generator.cpp
+)
+target_link_libraries(test_decomp_generator
+  ${library_name}
+)
+
 # Test headland
 ament_add_gtest(test_headland
   test_headland.cpp

--- a/opennav_coverage/test/test_decomp_generator.cpp
+++ b/opennav_coverage/test/test_decomp_generator.cpp
@@ -1,0 +1,145 @@
+// Copyright (c) 2023 Open Navigation LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
+#include "opennav_coverage/decomp_generator.hpp"
+#include "opennav_coverage_msgs/msg/decomp_mode.hpp"
+#include "fields2cover/utils/random.h"
+
+// Luckily, F2C has very high test coverage so we only need to test what we touch
+
+class RosLockGuard
+{
+public:
+  RosLockGuard() {rclcpp::init(0, nullptr);}
+  ~RosLockGuard() {rclcpp::shutdown();}
+};
+RosLockGuard g_rclcpp;
+
+namespace opennav_coverage
+{
+
+using opennav_coverage_msgs::msg::DecompMode;
+
+class DecompShim : public DecompGenerator
+{
+public:
+  template<typename NodeT>
+  explicit DecompShim(const NodeT & node)
+  : DecompGenerator(node)
+  {}
+
+  std::string toStringShim(const DecompType & type)
+  {
+    return toString(type);
+  }
+
+  DecompType toTypeShim(const std::string & str)
+  {
+    return toType(str);
+  }
+};
+
+TEST(DecompTests, TestDecompUtils)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto gen = DecompShim(node);
+
+  // toType: unknown -> UNKNOWN (not a throw)
+  EXPECT_EQ(gen.toTypeShim("FAKE"), DecompType::UNKNOWN);
+  EXPECT_EQ(gen.toTypeShim("UNKNOWN"), DecompType::UNKNOWN);
+
+  // toType: case-insensitivity
+  EXPECT_EQ(gen.toTypeShim("NONE"), DecompType::NONE);
+  EXPECT_EQ(gen.toTypeShim("none"), DecompType::NONE);
+  EXPECT_EQ(gen.toTypeShim("TRAPEZOIDAL"), DecompType::TRAPEZOIDAL);
+  EXPECT_EQ(gen.toTypeShim("trapezoidal"), DecompType::TRAPEZOIDAL);
+  EXPECT_EQ(gen.toTypeShim("BOUSTROPHEDON"), DecompType::BOUSTROPHEDON);
+  EXPECT_EQ(gen.toTypeShim("boustrophedon"), DecompType::BOUSTROPHEDON);
+
+  // toString
+  EXPECT_EQ(gen.toStringShim(DecompType::NONE), std::string("NONE"));
+  EXPECT_EQ(gen.toStringShim(DecompType::TRAPEZOIDAL), std::string("TRAPEZOIDAL"));
+  EXPECT_EQ(gen.toStringShim(DecompType::BOUSTROPHEDON), std::string("BOUSTROPHEDON"));
+  EXPECT_GT(gen.toStringShim(DecompType::UNKNOWN).size(), 0u);
+
+  // setters should not throw
+  gen.setMode("TRAPEZOIDAL");
+  gen.setMode("none");
+  gen.setSplitAngle(0.5 * M_PI);
+}
+
+TEST(DecompTests, TestDecompNone)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto gen = DecompShim(node);
+  f2c::Random rand;
+  auto field = rand.generateRandField(1e5, 5);
+  F2CCells cells;
+  cells.addGeometry(field.getField().getGeometry(0));
+
+  DecompMode mode;
+  mode.mode = "NONE";
+  F2CCells result = gen.decompose(cells, mode);
+  EXPECT_EQ(result.size(), 1u);
+}
+
+TEST(DecompTests, TestDecompNonConvex)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto gen = DecompShim(node);
+
+  // Build an L-shaped non-convex polygon by hand
+  F2CLinearRing ring;
+  ring.addPoint(0, 0);
+  ring.addPoint(10, 0);
+  ring.addPoint(10, 5);
+  ring.addPoint(5, 5);
+  ring.addPoint(5, 10);
+  ring.addPoint(0, 10);
+  ring.addPoint(0, 0);  // closed ring
+  F2CCell cell;
+  cell.addRing(ring);
+  F2CCells cells;
+  cells.addGeometry(cell);
+
+  DecompMode mode;
+  mode.mode = "TRAPEZOIDAL";
+  F2CCells result_trap = gen.decompose(cells, mode);
+  EXPECT_GT(result_trap.size(), 1u);  // L-field must split
+
+  // BOUSTROPHEDON extends TrapezoidalDecomp with a merge step, so its exact cell
+  // count is F2C-internal (may merge back to one). Only verify it produces valid,
+  // non-empty output without throwing.
+  mode.mode = "BOUSTROPHEDON";
+  F2CCells result_bou = gen.decompose(cells, mode);
+  EXPECT_GE(result_bou.size(), 1u);
+}
+
+TEST(DecompTests, TestDecompDefaultFallback)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto gen = DecompShim(node);
+  f2c::Random rand;
+  auto field = rand.generateRandField(1e5, 5);
+  F2CCells cells;
+  cells.addGeometry(field.getField().getGeometry(0));
+
+  DecompMode mode;  // default mode = "UNKNOWN" -> default_type_ = NONE
+  F2CCells result = gen.decompose(cells, mode);
+  EXPECT_EQ(result.size(), cells.size());  // behaves like NONE, unchanged
+}
+
+}  // namespace opennav_coverage

--- a/opennav_coverage/test/test_headland.cpp
+++ b/opennav_coverage/test/test_headland.cpp
@@ -89,4 +89,28 @@ TEST(HeadlandTests, TestheadlandGeneration)
   auto field_out2 = generator.generateHeadlands(field.getField().getGeometry(0), settings);
 }
 
+TEST(HeadlandTests, TestheadlandGenerationMultiCell)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto generator = HeadlandShim(node);
+
+  f2c::Random rand;
+  auto field = rand.generateRandField(1e5, 5);
+  Field cell = field.getField().getGeometry(0);
+  double area_in = cell.area();
+
+  // 2-cell F2CCells
+  F2CCells cells;
+  cells.addGeometry(cell);
+  cells.addGeometry(cell);
+
+  opennav_coverage_msgs::msg::HeadlandMode settings;
+  F2CCells result = generator.generateHeadlands(cells, settings);
+
+  EXPECT_EQ(result.size(), 2u);
+  // Each cell should have shrunk (headland removed)
+  EXPECT_LT(result.getGeometry(0).area(), area_in);
+  EXPECT_LT(result.getGeometry(1).area(), area_in);
+}
+
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_server.cpp
+++ b/opennav_coverage/test/test_server.cpp
@@ -119,6 +119,94 @@ TEST(ServerTest, testServerTransactions)
   EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
 }
 
+TEST(ServerTest, testDecompPath)
+{
+  // Create server
+  auto node = std::make_shared<ServerShim>();
+  rclcpp_lifecycle::State state;
+  node->configure(state);
+  node->activate(state);
+  auto node_thread = std::make_unique<nav2_util::NodeThread>(node);
+
+  auto client_node = std::make_shared<rclcpp::Node>("my_node_decomp");
+  auto action_client =
+    rclcpp_action::create_client<opennav_coverage_msgs::action::ComputeCoveragePath>(
+    client_node, "compute_coverage_path");
+  action_client->wait_for_action_server();
+
+  auto goal_msg = opennav_coverage_msgs::action::ComputeCoveragePath::Goal();
+  goal_msg.use_gml_file = true;
+  goal_msg.generate_decomp = true;
+  goal_msg.decomp_mode.mode = "TRAPEZOIDAL";
+  goal_msg.generate_headland = true;
+  goal_msg.generate_route = true;
+  goal_msg.generate_path = true;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::filesystem::path share_dir =
+    ament_index_cpp::get_package_share_directory("opennav_coverage");
+#pragma GCC diagnostic pop
+  goal_msg.gml_field = (share_dir / "test_field.xml").string();
+
+  auto future_goal_handle = action_client->async_send_goal(goal_msg);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_goal_handle),
+    rclcpp::FutureReturnCode::SUCCESS);
+  auto goal_handle = future_goal_handle.get();
+
+  auto future_result = action_client->async_get_result(goal_handle);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_result),
+    rclcpp::FutureReturnCode::SUCCESS);
+
+  auto result = future_result.get();
+  EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
+}
+
+TEST(ServerTest, testDecompPathNoHeadland)
+{
+  // generate_headland=false exercises the cells_no_headland = decomposed branch
+  auto node = std::make_shared<ServerShim>();
+  rclcpp_lifecycle::State state;
+  node->configure(state);
+  node->activate(state);
+  auto node_thread = std::make_unique<nav2_util::NodeThread>(node);
+
+  auto client_node = std::make_shared<rclcpp::Node>("my_node_decomp_nohl");
+  auto action_client =
+    rclcpp_action::create_client<opennav_coverage_msgs::action::ComputeCoveragePath>(
+    client_node, "compute_coverage_path");
+  action_client->wait_for_action_server();
+
+  auto goal_msg = opennav_coverage_msgs::action::ComputeCoveragePath::Goal();
+  goal_msg.use_gml_file = true;
+  goal_msg.generate_decomp = true;
+  goal_msg.decomp_mode.mode = "BOUSTROPHEDON";
+  goal_msg.generate_headland = false;
+  goal_msg.generate_route = false;
+  goal_msg.generate_path = false;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::filesystem::path share_dir =
+    ament_index_cpp::get_package_share_directory("opennav_coverage");
+#pragma GCC diagnostic pop
+  goal_msg.gml_field = (share_dir / "test_field.xml").string();
+
+  auto future_goal_handle = action_client->async_send_goal(goal_msg);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_goal_handle),
+    rclcpp::FutureReturnCode::SUCCESS);
+  auto goal_handle = future_goal_handle.get();
+
+  auto future_result = action_client->async_get_result(goal_handle);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_result),
+    rclcpp::FutureReturnCode::SUCCESS);
+
+  auto result = future_result.get();
+  EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
+}
+
 TEST(ServerTest, testDynamicParams)
 {
   auto node = std::make_shared<ServerShim>();

--- a/opennav_coverage/test/test_swath.cpp
+++ b/opennav_coverage/test/test_swath.cpp
@@ -104,7 +104,7 @@ TEST(SwathTests, TestswathUtils)
   generator.setSwathMode("SET_ANGLE");
   generator.setSwathAngle(0.0);
   generator.setOVerlap(false);
-  generator.setStepAngle(false);
+  generator.setStepAngle(0.0);
 }
 
 TEST(SwathTests, TestswathGeneration)
@@ -129,6 +129,32 @@ TEST(SwathTests, TestswathGeneration)
   settings.mode = "BRUTE_FORCE";
   settings.objective = "NUMBER_MODIFIED";
   auto swaths4 = generator.generateSwaths(field.getField().getGeometry(0), settings);
+}
+
+TEST(SwathTests, TestswathGenerationMultiCell)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot(node);
+  auto generator = SwathShim(node, &robot);
+
+  f2c::Random rand;
+  auto field = rand.generateRandField(1e5, 5);
+  Field cell = field.getField().getGeometry(0);
+
+  opennav_coverage_msgs::msg::SwathMode settings;
+
+  // Single-cell F2CCells routes through the Field path
+  F2CCells one_cell;
+  one_cell.addGeometry(cell);
+  auto swaths_one = generator.generateSwaths(one_cell, settings);
+  EXPECT_GT(swaths_one.size(), 0u);
+
+  // Multi-cell F2CCells flattens swaths across cells
+  F2CCells cells;
+  cells.addGeometry(cell);
+  cells.addGeometry(cell);
+  auto swaths_multi = generator.generateSwaths(cells, settings);
+  EXPECT_GT(swaths_multi.size(), swaths_one.size());
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -140,10 +140,10 @@ TEST(UtilsTests, TesttoCoveragePathMsg2)
   EXPECT_EQ(msg.contains_turns, true);
   EXPECT_EQ(msg.swaths_ordered, true);
 
-  // states are not valid (e.g. non-marked as turn or swath). v2 defaults type to
-  // SWATH, so explicitly set an unhandled type (HL_SWATH) to trigger the error.
+  // states are not valid (e.g. non-marked as turn or swath). SWATH/TURN/HL_SWATH
+  // are all handled now, so cast an out-of-range value to trigger the error.
   path_in.getStates().resize(10);
-  path_in.getStates()[0].type = f2c::types::PathSectionType::HL_SWATH;
+  path_in.getStates()[0].type = static_cast<f2c::types::PathSectionType>(99);
   EXPECT_THROW(util::toCoveragePathMsg(path_in, field, header_in, true), std::runtime_error);
 
   // Now lets make it valid
@@ -179,6 +179,78 @@ TEST(UtilsTests, TesttoCoveragePathMsg2)
   EXPECT_EQ(msg.swaths.size(), 2u);
   EXPECT_EQ(msg.turns.size(), 3u);
   EXPECT_EQ(msg.turns[0].poses.size(), 2u);
+}
+
+// HL_SWATH states (produced by decomposition) must be handled like SWATH.
+TEST(UtilsTests, TesttoCoveragePathMsgHLSwath)
+{
+  using f2c::types::PathSectionType;
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  F2CField field;
+
+  // Scenario 1: only HL_SWATH -> one swath, no turns
+  {
+    Path path_in;
+    path_in.getStates().resize(3);
+    path_in.getStates()[0].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[1].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[2].type = PathSectionType::HL_SWATH;
+
+    auto msg = util::toCoveragePathMsg(path_in, field, header_in, true);
+    EXPECT_EQ(msg.swaths.size(), 1u);
+    EXPECT_EQ(msg.turns.size(), 0u);
+    EXPECT_EQ(msg.contains_turns, true);
+    EXPECT_EQ(msg.swaths_ordered, true);
+  }
+
+  // Scenario 2: HL_SWATH -> TURN -> SWATH (realistic decomposition output)
+  {
+    Path path_in;
+    path_in.getStates().resize(6);
+    path_in.getStates()[0].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[1].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[2].type = PathSectionType::TURN;
+    path_in.getStates()[3].type = PathSectionType::TURN;
+    path_in.getStates()[4].type = PathSectionType::SWATH;
+    path_in.getStates()[5].type = PathSectionType::SWATH;
+
+    auto msg = util::toCoveragePathMsg(path_in, field, header_in, true);
+    EXPECT_EQ(msg.swaths.size(), 2u);
+    EXPECT_EQ(msg.turns.size(), 1u);
+    EXPECT_EQ(msg.turns[0].poses.size(), 2u);
+  }
+
+  // Scenario 3: SWATH + HL_SWATH mixed (both in the swath-like group)
+  {
+    Path path_in;
+    path_in.getStates().resize(7);
+    path_in.getStates()[0].type = PathSectionType::SWATH;
+    path_in.getStates()[1].type = PathSectionType::SWATH;
+    path_in.getStates()[2].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[3].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[4].type = PathSectionType::TURN;
+    path_in.getStates()[5].type = PathSectionType::TURN;
+    path_in.getStates()[6].type = PathSectionType::SWATH;
+
+    auto msg = util::toCoveragePathMsg(path_in, field, header_in, true);
+    EXPECT_EQ(msg.swaths.size(), 2u);  // SWATH->HL_SWATH is a no-op (same swath block)
+    EXPECT_EQ(msg.turns.size(), 1u);
+  }
+
+  // Scenario 4: start with TURN, then transition to HL_SWATH (TURN -> swath-like edge)
+  {
+    Path path_in;
+    path_in.getStates().resize(4);
+    path_in.getStates()[0].type = PathSectionType::TURN;
+    path_in.getStates()[1].type = PathSectionType::TURN;
+    path_in.getStates()[2].type = PathSectionType::HL_SWATH;
+    path_in.getStates()[3].type = PathSectionType::HL_SWATH;
+
+    auto msg = util::toCoveragePathMsg(path_in, field, header_in, true);
+    EXPECT_EQ(msg.turns.size(), 1u);
+    EXPECT_EQ(msg.swaths.size(), 1u);
+  }
 }
 
 TEST(UtilsTests, TestgetFieldFromGoal)
@@ -396,6 +468,44 @@ TEST(UtilsTests, TesttoNavPathMsgWithVelocity)
   // TURN state: velocity=0.5, direction=FORWARD
   EXPECT_NEAR(vels.back(), 0.5, 1e-6);
   EXPECT_FALSE(dirs.back());
+}
+
+// HL_SWATH states must carry velocity/direction through toNavPathMsg like SWATH does.
+TEST(UtilsTests, TesttoNavPathMsgHLSwathVelocity)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState hl_swath;
+  hl_swath.type = f2c::types::PathSectionType::HL_SWATH;
+  hl_swath.point = Point(0.0, 0.0);
+  hl_swath.len = 1.0;
+  hl_swath.angle = 0.0;
+  hl_swath.velocity = 1.5;
+  hl_swath.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(hl_swath);
+
+  PathState turn;
+  turn.type = f2c::types::PathSectionType::TURN;
+  turn.velocity = 0.5;
+  turn.dir = f2c::types::PathDirection::BACKWARD;
+  path_in.addState(turn);
+
+  F2CField field;
+  std::vector<double> vels;
+  std::vector<bool> dirs;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f, &vels, &dirs);
+
+  EXPECT_EQ(nav_path.poses.size(), vels.size());
+  EXPECT_EQ(nav_path.poses.size(), dirs.size());
+  // HL_SWATH state: velocity=1.5, direction=FORWARD, passes through as one point
+  // (discretizeSwath does not densify HL_SWATH, only SWATH)
+  EXPECT_NEAR(vels[0], 1.5, 1e-6);
+  EXPECT_FALSE(dirs[0]);
+  // TURN state: velocity=0.5, direction=BACKWARD
+  EXPECT_NEAR(vels.back(), 0.5, 1e-6);
+  EXPECT_TRUE(dirs.back());
 }
 
 // B.6+B.7 integration: poses, velocities, is_backward sizes must match after discretizeSwath

--- a/opennav_coverage_bt/include/opennav_coverage_bt/compute_complete_coverage_path.hpp
+++ b/opennav_coverage_bt/include/opennav_coverage_bt/compute_complete_coverage_path.hpp
@@ -82,6 +82,10 @@ public:
   {
     return providedBasicPorts(
       {
+        BT::InputPort<bool>("generate_decomp", false, "Whether to decompose non-convex field"),
+        BT::InputPort<std::string>(
+          "decomp_mode_type", "UNKNOWN", "NONE/TRAPEZOIDAL/BOUSTROPHEDON"),
+        BT::InputPort<double>("decomp_split_angle", 0.0, "Split angle in radians"),
         BT::InputPort<bool>("generate_headland", true, "Whether to generate headland"),
         BT::InputPort<bool>("generate_route", true, "Whether to ordered route of swaths"),
         BT::InputPort<bool>("generate_path", true, "Whether to generate connected path of routes"),

--- a/opennav_coverage_bt/src/compute_complete_coverage_path.cpp
+++ b/opennav_coverage_bt/src/compute_complete_coverage_path.cpp
@@ -31,6 +31,11 @@ ComputeCoveragePathAction::ComputeCoveragePathAction(
 void ComputeCoveragePathAction::on_tick()
 {
   // Get core inputs about what to perform
+  getInput("generate_decomp", goal_.generate_decomp);
+  std::string decomp_type;
+  getInput("decomp_mode_type", decomp_type);
+  goal_.decomp_mode.mode = decomp_type;
+  getInput("decomp_split_angle", goal_.decomp_mode.split_angle);
   getInput("generate_headland", goal_.generate_headland);
   getInput("generate_route", goal_.generate_route);
   getInput("generate_path", goal_.generate_path);

--- a/opennav_coverage_bt/test/test_compute_coverage_path.cpp
+++ b/opennav_coverage_bt/test/test_compute_coverage_path.cpp
@@ -33,6 +33,11 @@ public:
   : TestActionServer("compute_coverage_path")
   {}
 
+  const opennav_coverage_msgs::action::ComputeCoveragePath::Goal & getReceivedGoal() const
+  {
+    return last_goal_;
+  }
+
 protected:
   void execute(
     const typename std::shared_ptr<
@@ -41,6 +46,7 @@ protected:
   override
   {
     const auto goal = goal_handle->get_goal();
+    last_goal_ = *goal;
     auto result =
       std::make_shared<opennav_coverage_msgs::action::ComputeCoveragePath::Result>();
     result->nav_path.poses.resize(2);
@@ -48,6 +54,9 @@ protected:
     result->nav_path.poses[0].pose.position.x = 0.0;
     goal_handle->succeed(result);
   }
+
+private:
+  opennav_coverage_msgs::action::ComputeCoveragePath::Goal last_goal_;
 };
 
 class ComputeCoveragePathActionTestFixture : public ::testing::Test
@@ -149,6 +158,37 @@ TEST_F(ComputeCoveragePathActionTestFixture, test_tick)
   // halt node so another goal can be sent
   tree_->haltTree();
   EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::IDLE);
+}
+
+TEST_F(ComputeCoveragePathActionTestFixture, test_decomp_ports)
+{
+  // generate_decomp=true and decomp_mode_type must flow from the BT XML to the goal
+  std::string xml_txt =
+    R"(
+      <root BTCPP_format="4" main_tree_to_execute="MainTree">
+        <BehaviorTree ID="MainTree">
+            <ComputeCoveragePath
+              nav_path="{path}"
+              generate_decomp="true"
+              decomp_mode_type="TRAPEZOIDAL"
+              decomp_split_angle="1.5708"/>
+        </BehaviorTree>
+      </root>)";
+
+  tree_ = std::make_shared<BT::Tree>(factory_->createTreeFromText(xml_txt, config_->blackboard));
+
+  while (tree_->rootNode()->status() != BT::NodeStatus::SUCCESS) {
+    tree_->rootNode()->executeTick();
+  }
+  EXPECT_EQ(tree_->rootNode()->status(), BT::NodeStatus::SUCCESS);
+
+  // Verify the decomp ports reached the server goal
+  const auto & goal = action_server_->getReceivedGoal();
+  EXPECT_TRUE(goal.generate_decomp);
+  EXPECT_EQ(goal.decomp_mode.mode, std::string("TRAPEZOIDAL"));
+  EXPECT_NEAR(goal.decomp_mode.split_angle, 1.5708, 1e-4);
+
+  tree_->haltTree();
 }
 
 int main(int argc, char ** argv)

--- a/opennav_coverage_demo/params/demo_params.yaml
+++ b/opennav_coverage_demo/params/demo_params.yaml
@@ -10,6 +10,9 @@ coverage_server:
     default_allow_overlap: false
     default_swath_angle_type: "SET_ANGLE"
     default_swath_angle: 0.0 # We know its aligned for the demo
+    default_generate_decomp: false       # true enables decomposition for all missions
+    default_decomp_type: "NONE"          # NONE / TRAPEZOIDAL / BOUSTROPHEDON
+    default_decomp_split_angle: 0.0      # radians; 0 = split parallel to swath angle
 
 row_coverage_server:
   ros__parameters:

--- a/opennav_coverage_msgs/CMakeLists.txt
+++ b/opennav_coverage_msgs/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(action_msgs REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/Coordinate.msg"
   "msg/Coordinates.msg"
+  "msg/DecompMode.msg"
   "msg/HeadlandMode.msg"
   "msg/SwathMode.msg"
   "msg/RowSwathMode.msg"

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -1,6 +1,8 @@
 #goal definition
 
 # Whether to perform all 4 stages: Headlands, Swath (Required), Route, Path
+bool generate_decomp False
+opennav_coverage_msgs/DecompMode decomp_mode
 bool generate_headland True
 bool generate_route True
 bool generate_path True

--- a/opennav_coverage_msgs/msg/DecompMode.msg
+++ b/opennav_coverage_msgs/msg/DecompMode.msg
@@ -1,0 +1,4 @@
+string mode "UNKNOWN"  # NONE, TRAPEZOIDAL, BOUSTROPHEDON
+
+# Specific mode setting
+float64 split_angle 0.0  # split angle in radians; 0 = use node default (default_decomp_split_angle)


### PR DESCRIPTION
## Summary

Adds optional **field decomposition** — splitting a non-convex field into
sub-cells before swath/headland generation — plus the `HL_SWATH` path handling
that decomposed fields require. Builds on #121.

## Changes

**Field decomposition (core)**
- `DecompType` enum: `NONE`, `TRAPEZOIDAL`, `BOUSTROPHEDON`.
- `DecompGenerator`: wraps the Fields2Cover decomposition, selectable via mode
  and `split_angle`.
- Multi-cell overloads for the swath and headland generators, operating on the
  `F2CCells` produced by decomposition.
- Wired into `coverage_server` behind a single gate: the `generate_decomp` goal
  flag **or** a `default_generate_decomp` YAML parameter.
- BT node ports exposing decomposition control.

**HL_SWATH handling**
- Decomposition emits `HL_SWATH` states for inter-cell headland passes.
  `toCoveragePathMsg`/`toNavPathMsg` now treat `HL_SWATH` like `SWATH`, so
  decomposed fields no longer crash the server.

## Interface changes (additive)

- `DecompMode.msg` (new): `string mode`, `float64 split_angle`.
- `ComputeCoveragePath.action`: `+ bool generate_decomp`, `+ DecompMode decomp_mode`.
- `types.hpp`: `+ enum class DecompType`.

## Note

This is the `jazzy` port of open-navigation#113. Content matches the rolling PR
file-for-file; the only differences are the `jazzy`-specific API surface
(`nav2_util::` instead of `nav2::`/`nav2_ros_common`). The rolling-only CI
workflow changes are intentionally omitted. The TSP route planning follows in
the next PR of the series.
