### PR TITLE
Multi-cell TSP routing, route corridors, and optional headland driving for decomposed fields

### DIFF
--- a/opennav_coverage/include/opennav_coverage/coverage_server.hpp
+++ b/opennav_coverage/include/opennav_coverage/coverage_server.hpp
@@ -132,6 +132,7 @@ protected:
   std::unique_ptr<Visualizer> visualizer_;
   bool cartesian_frame_;
   bool default_generate_decomp_{false};
+  bool default_generate_headland_swaths_{false};
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/include/opennav_coverage/headland_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/headland_generator.hpp
@@ -75,6 +75,16 @@ public:
     const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings);
 
   /**
+   * @brief Carve a route corridor only on the borders cells actually share,
+   *        leaving edges facing the outer boundary or a void untouched.
+   * @param cells Decomposed sub-cells (share internal borders)
+   * @param route_width Corridor width carved along each shared border
+   * @return Swath cells carved only on their internal borders
+   */
+  F2CCells generateHeadlandsBetweenCells(
+    const F2CCells & cells, double route_width);
+
+  /**
    * @brief Generate concentric rings that fully sweep the headland band.
    *        Pass count is derived from the headland width and the operation
    *        width (round(width / operation_width), min 1).

--- a/opennav_coverage/include/opennav_coverage/headland_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/headland_generator.hpp
@@ -15,6 +15,7 @@
 #ifndef OPENNAV_COVERAGE__HEADLAND_GENERATOR_HPP_
 #define OPENNAV_COVERAGE__HEADLAND_GENERATOR_HPP_
 
+#include <cmath>
 #include <vector>
 #include <string>
 
@@ -72,6 +73,19 @@ public:
    */
   F2CCells generateHeadlands(
     const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings);
+
+  /**
+   * @brief Generate concentric rings that fully sweep the headland band.
+   *        Pass count is derived from the headland width and the operation
+   *        width (round(width / operation_width), min 1).
+   * @param field Full field (before headland removal)
+   * @param operation_width Spacing between rings
+   * @param settings Action request information (headland mode/width)
+   * @return Rings ordered outer to inner; each F2CCells is one pass
+   */
+  std::vector<F2CCells> generateHeadlandSwaths(
+    const Field & field, double operation_width,
+    const opennav_coverage_msgs::msg::HeadlandMode & settings);
 
   /**
    * @brief Sets the mode manually of the Headland for dynamic parameters

--- a/opennav_coverage/include/opennav_coverage/path_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/path_generator.hpp
@@ -118,6 +118,28 @@ public:
 
 protected:
   /**
+   * @brief Assemble the full path: swath groups via F2C planPath, connections
+   *        via appendConnection (see there for why connections aren't just
+   *        handed to F2C's own route-level planPath).
+   * @param route Route with ordered swath groups and connections
+   * @param curve Curve generator for turns
+   * @return Full path
+   */
+  Path assemblePath(const F2CRoute & route, f2c::pp::TurningBase & curve);
+
+  /**
+   * @brief Append one connection between swath groups to the path
+   * @param path Path to append to
+   * @param prev Previous swath group (may be empty at the route start)
+   * @param connection Connection waypoints from the route (may be empty)
+   * @param next Next swath group (may be empty at the route end)
+   * @param curve Curve generator used when there is no polyline to follow
+   */
+  void appendConnection(
+    Path & path, const Swaths & prev, const F2CMultiPoint & connection,
+    const Swaths & next, f2c::pp::TurningBase & curve);
+
+  /**
    * @brief Creates generator pointer of a requested type
    * @param type curve generator type to create
    * @return Generator to use

--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -118,9 +118,9 @@ public:
     const F2CCells & cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
-    const std::optional<F2CPoint> & start_end = std::nullopt)
+    const std::optional<F2CPoint> & start_end_point = std::nullopt)
   {
-    return generateRoute(cells, cells, swaths_by_cells, settings, start_end);
+    return generateRoute(cells, cells, swaths_by_cells, settings, start_end_point);
   }
 
   /**

--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -110,6 +110,21 @@ public:
     const std::optional<F2CPoint> & start_end_point = std::nullopt);
 
   /**
+   * @brief Whether the request (or the default it falls back to) is TSP.
+   *        Used to reject non-TSP + decomposition before any geometry work.
+   * @param settings Action request information
+   * @return true when the route mode resolves to TSP
+   */
+  bool resolvesToTsp(const opennav_coverage_msgs::msg::RouteMode & settings)
+  {
+    RouteType type = toType(settings.mode);
+    if (type == RouteType::UNKNOWN) {
+      type = default_type_;
+    }
+    return type == RouteType::TSP;
+  }
+
+  /**
    * @brief Sets the mode manually of the Route for dynamic parameters
    * @param mode String for mode to use
    */

--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -97,17 +97,31 @@ public:
 
   /**
    * @brief Generate an ordered route for any mode (orderers or TSP).
-   * @param cells Travel cells whose borders route connections may follow
+   * @param travel_cells Border-sharing cells inter-cell bridges may follow
+   * @param swath_cells Cells the swaths were generated from (carved corridors)
    * @param swaths_by_cells Per-cell swaths from generateSwathsByCells
    * @param settings Action request information
    * @param start_end_point Optional start/end point for the route (TSP mode only)
    * @return F2CRoute (ordered swath groups plus any connections)
    */
   F2CRoute generateRoute(
-    const F2CCells & cells,
+    const F2CCells & travel_cells,
+    const F2CCells & swath_cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
     const std::optional<F2CPoint> & start_end_point = std::nullopt);
+
+  /**
+   * @brief Convenience overload when the travel and swath cells are the same
+   */
+  F2CRoute generateRoute(
+    const F2CCells & cells,
+    const F2CSwathsByCells & swaths_by_cells,
+    const opennav_coverage_msgs::msg::RouteMode & settings,
+    const std::optional<F2CPoint> & start_end = std::nullopt)
+  {
+    return generateRoute(cells, cells, swaths_by_cells, settings, start_end);
+  }
 
   /**
    * @brief Whether the request (or the default it falls back to) is TSP.

--- a/opennav_coverage/include/opennav_coverage/route_method.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_method.hpp
@@ -41,14 +41,16 @@ public:
 
   /**
    * @brief Plan an ordered route over the swaths.
-   * @param cells Travel cells whose borders the route connections may follow
-   * @param swaths_by_cells Per-cell swaths to be covered
+   * @param travel_cells Border-sharing cells the inter-cell bridges may follow
+   * @param swath_cells Cells the swaths were generated from (carved corridors)
+   * @param swaths_by_cells Per-cell swaths, indexed like swath_cells
    * @param settings Fully-resolved RouteMode (server has already applied defaults)
    * @param start_end_point Optional start/end point for the route (used by TSP only)
    * @return Ordered route: swath groups plus any headland connections
    */
   virtual F2CRoute plan(
-    const F2CCells & cells,
+    const F2CCells & travel_cells,
+    const F2CCells & swath_cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
     const std::optional<F2CPoint> & start_end_point = std::nullopt) = 0;
@@ -69,7 +71,8 @@ public:
   : type_(type), orderer_(std::move(orderer)) {}
 
   F2CRoute plan(
-    const F2CCells & cells,
+    const F2CCells & travel_cells,
+    const F2CCells & swath_cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
     const std::optional<F2CPoint> & start_end_point = std::nullopt) override;
@@ -81,18 +84,20 @@ private:
 
 /**
  * @class TspRouteMethod
- * @brief Adapts F2C's `RoutePlannerBase` (OR-Tools TSP). Solves each cell
- *        separately and stitches the per-cell routes in sweep order, avoiding the
- *        all-pairs path matrix that exhausts memory on decomposed multi-cell input.
+ * @brief Adapts F2C's `RoutePlannerBase` (OR-Tools TSP). Single-cell input is one
+ *        genRoute call. Multi-cell input is solved per cell and stitched in
+ *        nearest-neighbor order (see route_method.cpp), keeping cells contiguous.
  */
 class TspRouteMethod : public RouteMethod
 {
 public:
+  // max_swaths_for_global_route: unused, kept for ABI/call-site stability
   TspRouteMethod(const rclcpp::Logger & logger, size_t max_swaths_for_global_route)
   : logger_(logger), max_swaths_for_global_route_(max_swaths_for_global_route) {}
 
   F2CRoute plan(
-    const F2CCells & cells,
+    const F2CCells & travel_cells,
+    const F2CCells & swath_cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
     const std::optional<F2CPoint> & start_end_point = std::nullopt) override;

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -15,6 +15,7 @@
 #ifndef OPENNAV_COVERAGE__UTILS_HPP_
 #define OPENNAV_COVERAGE__UTILS_HPP_
 
+#include <cmath>
 #include <vector>
 #include <string>
 #include <algorithm>
@@ -229,6 +230,86 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
 }
 
 /**
+ * @brief Build a drivable HL_SWATH loop around a field boundary, rotated to start
+ * at the vertex closest to `anchor` (the route's first point) to minimize the
+ * jump when spliced onto the coverage path. Density added later by discretizeSwathLike.
+ * @param area Field/cell whose exterior boundary is driven (e.g. field_no_headland)
+ * @param velocity Cruise velocity to tag each state with
+ * @param anchor Point the loop's start/end should be nearest to
+ * @return Path of HL_SWATH states (empty if the boundary has < 2 points)
+ */
+inline Path toHeadlandPerimeterPath(
+  const Field & area, double velocity, const Point & anchor)
+{
+  Path path;
+  const Polygon ring = area.getExteriorRing();  // closed boundary loop (first == last point)
+  const size_t n = ring.size();
+  if (n < 2) {
+    return path;
+  }
+  const size_t n_unique = n - 1;  // exclude the duplicated closing point
+
+  size_t start_idx = 0;
+  double best_dist2 = 0.0;
+  for (size_t i = 0; i < n_unique; ++i) {
+    const Point p = ring.getGeometry(i);
+    const double dx = p.getX() - anchor.getX();
+    const double dy = p.getY() - anchor.getY();
+    const double d2 = dx * dx + dy * dy;
+    if (i == 0 || d2 < best_dist2) {
+      best_dist2 = d2;
+      start_idx = i;
+    }
+  }
+
+  for (size_t k = 0; k < n_unique; ++k) {
+    const Point p0 = ring.getGeometry((start_idx + k) % n_unique);
+    const Point p1 = ring.getGeometry((start_idx + k + 1) % n_unique);
+    const double dx = p1.getX() - p0.getX();
+    const double dy = p1.getY() - p0.getY();
+    PathState s;
+    s.point = p0;
+    s.angle = std::atan2(dy, dx);
+    s.len = std::hypot(dx, dy);
+    s.dir = f2c::types::PathDirection::FORWARD;
+    s.type = f2c::types::PathSectionType::HL_SWATH;
+    s.velocity = velocity;
+    path.addState(s);
+  }
+  return path;
+}
+
+/**
+ * @brief Like F2C Path::discretizeSwath but also splits HL_SWATH states, so
+ * headland passes become dense followable segments. F2C's discretizeSwath only
+ * subdivides SWATH; HL_SWATH would otherwise pass through as a single waypoint.
+ * @param path Path to densify
+ * @param step_size Max spacing between emitted points
+ * @return Densified path
+ */
+inline Path discretizeSwathLike(const Path & path, double step_size)
+{
+  using f2c::types::PathSectionType;
+  Path out;
+  const double step = step_size > 0.0 ? step_size : 0.1;
+  for (const auto & s : path.getStates()) {
+    if (s.type == PathSectionType::SWATH || s.type == PathSectionType::HL_SWATH) {
+      double n_steps = std::max(1.0, std::round(std::fabs(s.len / step)));
+      Point start2end = s.atEnd() - s.point;
+      for (double j = 0.0; j < n_steps; j += 1.0) {
+        PathState state = s;
+        state.point = s.point + start2end * (j / n_steps);
+        state.len /= n_steps;
+        out.addState(state);
+      }
+    } else {
+      out.addState(s);
+    }
+  }
+  return out;
+}
+
+/**
  * @brief Converts full path to nav_msgs/path message for action client, visualization
  * and use in direct-sending to a controller to replace the planner server. Interpolates
  * the F2C path to make it dense for following semantics.
@@ -263,8 +344,9 @@ inline nav_msgs::msg::Path toNavPathMsg(
     path.moveTo(field.getRefPoint());
   }
 
-  // discretizeSwath splits only SWATH states at step_size intervals
-  path = path.discretizeSwath(static_cast<double>(pt_dist));
+  // Split SWATH and HL_SWATH states at step_size intervals (F2C's discretizeSwath
+  // splits only SWATH, leaving headland passes as single waypoints).
+  path = discretizeSwathLike(path, static_cast<double>(pt_dist));
 
   // Reserve up front so the population loop below doesn't reallocate.
   const auto n = path.size();

--- a/opennav_coverage/include/opennav_coverage/visualizer.hpp
+++ b/opennav_coverage/include/opennav_coverage/visualizer.hpp
@@ -56,6 +56,9 @@ public:
     swaths_pub_ = rclcpp::create_publisher<visualization_msgs::msg::Marker>(
       node->get_node_topics_interface(),
       "coverage_server/swaths", rclcpp::QoS(1));
+    headland_swaths_pub_ = rclcpp::create_publisher<visualization_msgs::msg::Marker>(
+      node->get_node_topics_interface(),
+      "coverage_server/headland_swaths", rclcpp::QoS(1));
   }
 
   void deactivate();
@@ -63,12 +66,14 @@ public:
   void visualize(
     const Field & total_field, const Field & no_headland_field,
     const Point & ref_pt, const nav_msgs::msg::Path & path,
-    const Swaths swaths, const std_msgs::msg::Header & header);
+    const Swaths swaths, const std_msgs::msg::Header & header,
+    const Path & headland_path = Path());
 
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr nav_plan_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr headlands_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr planning_field_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr swaths_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr headland_swaths_pub_;
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/include/opennav_coverage/visualizer.hpp
+++ b/opennav_coverage/include/opennav_coverage/visualizer.hpp
@@ -59,6 +59,9 @@ public:
     headland_swaths_pub_ = rclcpp::create_publisher<visualization_msgs::msg::Marker>(
       node->get_node_topics_interface(),
       "coverage_server/headland_swaths", rclcpp::QoS(1));
+    swath_cells_pub_ = rclcpp::create_publisher<visualization_msgs::msg::Marker>(
+      node->get_node_topics_interface(),
+      "coverage_server/swath_cells", rclcpp::QoS(1));
   }
 
   void deactivate();
@@ -67,13 +70,15 @@ public:
     const Field & total_field, const Field & no_headland_field,
     const Point & ref_pt, const nav_msgs::msg::Path & path,
     const Swaths swaths, const std_msgs::msg::Header & header,
-    const Path & headland_path = Path());
+    const Path & headland_path = Path(),
+    const F2CCells & swath_cells = F2CCells());
 
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr nav_plan_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr headlands_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr planning_field_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr swaths_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr headland_swaths_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr swath_cells_pub_;
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -261,14 +261,14 @@ void CoverageServer::computeCoveragePath()
         "skipping the headland perimeter pass.");
     }
     if (goal->generate_route) {
-      std::optional<F2CPoint> start_end;
+      std::optional<F2CPoint> start_end_point;
       if (goal->use_start_pose) {
-        start_end = util::toFieldFrame(
+        start_end_point = util::toFieldFrame(
           F2CPoint(goal->start_pose.axis1, goal->start_pose.axis2), master_field, cartesian_frame_);
       }
       // Per-cell routes pair with swath_cells; bridges travel route_cells to detour voids.
       F2CRoute route = route_gen_->generateRoute(
-        route_cells, swath_cells, swaths_by_cells, goal->route_mode, start_end);
+        route_cells, swath_cells, swaths_by_cells, goal->route_mode, start_end_point);
       if (route.isEmpty()) {
         throw CoverageException("Route planner returned an empty route.");
       }

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -206,9 +206,8 @@ void CoverageServer::computeCoveragePath()
     F2CCells route_cells;
     F2CCells swath_cells;
     if (do_decomp) {
-      // Headland-first: remove the headland from the whole field, decompose that into
-      // border-sharing cells (the travel graph), then remove the headland again per
-      // cell for the swaths, so connections run along the shared headland.
+      // Headland-first: remove the headland once from the whole field, then
+      // decompose that into border-sharing cells (the travel graph).
       Field travel_ring = field;
       if (goal->generate_headland) {
         travel_ring = headland_gen_->generateHeadlands(field, goal->headland_mode);
@@ -217,8 +216,14 @@ void CoverageServer::computeCoveragePath()
       F2CCells travel_ring_cells;
       travel_ring_cells.addGeometry(travel_ring);
       route_cells = decomp_gen_->decompose(travel_ring_cells, goal->decomp_mode);
-      swath_cells = goal->generate_headland ?
-        headland_gen_->generateHeadlands(route_cells, goal->headland_mode) : route_cells;
+      if (!goal->generate_headland) {
+        swath_cells = route_cells;
+      } else {
+        // Headland already removed before decomposing; only carve the inter-cell corridor here.
+        const double route_w = goal->route_headland_width > 0.0 ?
+          goal->route_headland_width : robot_params_->getOperationWidth();
+        swath_cells = headland_gen_->generateHeadlandsBetweenCells(route_cells, route_w);
+      }
     } else {
       // No decomposition: remove the headland from the single field cell
       if (goal->generate_headland) {
@@ -316,7 +321,7 @@ void CoverageServer::computeCoveragePath()
     visualizer_->visualize(
       field, field_no_headland, master_field.getRefPoint(),
       util::toCartesianNavPathMsg(path, header, path_gen_->getTurnPointDistance()),
-      swaths, header, headland_path);
+      swaths, header, headland_path, swath_cells);
     action_server_->succeeded_current(result);
   } catch (CoverageException & e) {
     RCLCPP_ERROR(get_logger(), "Invalid mode set: %s", e.what());

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -48,6 +48,10 @@ CoverageServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     node, "default_generate_decomp", rclcpp::ParameterValue(false));
   get_parameter("default_generate_decomp", default_generate_decomp_);
 
+  nav2::declare_parameter_if_not_declared(
+    node, "default_generate_headland_swaths", rclcpp::ParameterValue(false));
+  get_parameter("default_generate_headland_swaths", default_generate_headland_swaths_);
+
   // If in GPS coordinates, we must convert to a CRS to compute coverage
   // Then, reconvert back to GPS for the user.
   nav2::declare_parameter_if_not_declared(
@@ -234,6 +238,16 @@ void CoverageServer::computeCoveragePath()
     header.stamp = now();
     header.frame_id = frame_id;
     Path path;
+    Path headland_path;  // kept for visualization after being spliced into path
+    // Optional: also drive the headland perimeter; needs the full route+path pipeline.
+    const bool do_headland_swaths =
+      goal->generate_headland_swaths || default_generate_headland_swaths_;
+    if (do_headland_swaths && !(goal->generate_route && goal->generate_path)) {
+      RCLCPP_WARN(
+        get_logger(),
+        "generate_headland_swaths needs generate_route and generate_path; "
+        "skipping the headland perimeter pass.");
+    }
     if (goal->generate_route) {
       std::optional<F2CPoint> start_end_point;
       if (goal->use_start_pose) {
@@ -250,6 +264,34 @@ void CoverageServer::computeCoveragePath()
       // Converts UTM back to GPS, if necessary, for action returns
       if (goal->generate_path) {
         path = path_gen_->generatePath(route, goal->path_mode);
+
+        // Prepend/append the headland pass(es); loops start near the route to minimize the jump.
+        if (do_headland_swaths) {
+          const double cruise_vel = robot_params_->getRobot().getCruiseVel();
+          if (goal->headland_full_coverage) {
+            // Concentric passes (outer to inner) sweeping the whole band
+            const auto rings = headland_gen_->generateHeadlandSwaths(
+              field, robot_params_->getOperationWidth(), goal->headland_mode);
+            for (const auto & ring : rings) {
+              for (size_t c = 0; c < ring.size(); ++c) {
+                headland_path += util::toHeadlandPerimeterPath(
+                  ring.getGeometry(c), cruise_vel, path[0].point);
+              }
+            }
+          } else {
+            // Single perimeter pass along the headland's inner boundary
+            headland_path = util::toHeadlandPerimeterPath(
+              field_no_headland, cruise_vel, path[0].point);
+          }
+          if (goal->headland_first) {
+            Path combined = headland_path;
+            combined += path;
+            path = combined;
+          } else {
+            path += headland_path;
+          }
+        }
+
         result->coverage_path =
           util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = util::toNavPathMsg(
@@ -274,7 +316,7 @@ void CoverageServer::computeCoveragePath()
     visualizer_->visualize(
       field, field_no_headland, master_field.getRefPoint(),
       util::toCartesianNavPathMsg(path, header, path_gen_->getTurnPointDistance()),
-      swaths, header);
+      swaths, header, headland_path);
     action_server_->succeeded_current(result);
   } catch (CoverageException & e) {
     RCLCPP_ERROR(get_logger(), "Invalid mode set: %s", e.what());
@@ -344,6 +386,8 @@ CoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramet
         route_gen_->setTspSearchForOptimum(parameter.as_bool());
       } else if (name == "default_reduce_path") {
         path_gen_->setReducePath(parameter.as_bool());
+      } else if (name == "default_generate_headland_swaths") {
+        default_generate_headland_swaths_ = parameter.as_bool();
       }
     } else if (type == ParameterType::PARAMETER_INTEGER) {
       if (name == "default_spiral_n") {

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -200,6 +200,13 @@ void CoverageServer::computeCoveragePath()
     // (1) Build the cells to cover: remove the headland, optionally decomposing first
     const bool do_decomp = goal->generate_decomp || default_generate_decomp_;
 
+    // Reject non-TSP+decomp up front; the deep check only fires after all the geometry work.
+    if (do_decomp && goal->generate_route && !route_gen_->resolvesToTsp(goal->route_mode)) {
+      throw CoverageException(
+              "Non-TSP route modes are not supported with field decomposition; "
+              "use route_mode TSP or disable decomposition.");
+    }
+
     Field field_no_headland = field;
     // route_cells: travel graph for the route planner. swath_cells: cells swaths
     // are generated from. Differ only when decomposing with a headland.
@@ -365,6 +372,12 @@ CoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramet
       } else if (name == "operation_width") {
         auto & robot = robot_params_->getRobot();
         robot.setCovWidth(parameter.as_double());
+      } else if (name == "min_turning_radius") {
+        auto & robot = robot_params_->getRobot();
+        robot.setMinTurningRadius(parameter.as_double());
+      } else if (name == "linear_curv_change") {
+        auto & robot = robot_params_->getRobot();
+        robot.setMaxDiffCurv(parameter.as_double());
       }
     } else if (type == ParameterType::PARAMETER_STRING) {
       if (name == "default_headland_type") {

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -261,13 +261,14 @@ void CoverageServer::computeCoveragePath()
         "skipping the headland perimeter pass.");
     }
     if (goal->generate_route) {
-      std::optional<F2CPoint> start_end_point;
+      std::optional<F2CPoint> start_end;
       if (goal->use_start_pose) {
-        start_end_point = util::toFieldFrame(
+        start_end = util::toFieldFrame(
           F2CPoint(goal->start_pose.axis1, goal->start_pose.axis2), master_field, cartesian_frame_);
       }
-      F2CRoute route =
-        route_gen_->generateRoute(route_cells, swaths_by_cells, goal->route_mode, start_end_point);
+      // Per-cell routes pair with swath_cells; bridges travel route_cells to detour voids.
+      F2CRoute route = route_gen_->generateRoute(
+        route_cells, swath_cells, swaths_by_cells, goal->route_mode, start_end);
       if (route.isEmpty()) {
         throw CoverageException("Route planner returned an empty route.");
       }

--- a/opennav_coverage/src/headland_generator.cpp
+++ b/opennav_coverage/src/headland_generator.cpp
@@ -80,6 +80,27 @@ F2CCells HeadlandGenerator::generateHeadlands(
   return result;
 }
 
+std::vector<F2CCells> HeadlandGenerator::generateHeadlandSwaths(
+  const Field & field, double operation_width,
+  const opennav_coverage_msgs::msg::HeadlandMode & settings)
+{
+  if (operation_width <= 0.0) {
+    throw CoverageException(
+      "Operation width must be > 0 to sweep the headland band (set operation_width).");
+  }
+
+  double width = 0.0;
+  HeadlandGeneratorPtr generator = resolveGenerator(settings, width);
+
+  // Number of passes needed to sweep the band at operation-width spacing
+  int n_swaths = static_cast<int>(std::round(width / operation_width));
+  if (n_swaths < 1) {
+    n_swaths = 1;
+  }
+
+  return generator->generateHeadlandSwaths(Fields(field), operation_width, n_swaths, true);
+}
+
 void HeadlandGenerator::setMode(const std::string & new_mode)
 {
   default_type_ = toType(new_mode);

--- a/opennav_coverage/src/headland_generator.cpp
+++ b/opennav_coverage/src/headland_generator.cpp
@@ -80,6 +80,59 @@ F2CCells HeadlandGenerator::generateHeadlands(
   return result;
 }
 
+F2CCells HeadlandGenerator::generateHeadlandsBetweenCells(
+  const F2CCells & cells, double route_width)
+{
+  if (route_width <= 0.0) {
+    throw CoverageException("route_headland_width must be > 0 to carve inter-cell corridors.");
+  }
+
+  // kMinCellArea drops slivers left by carving: F2C's unchecked geometry casts
+  // corrupt memory on degenerate (near-zero-area) polygons.
+  const double kSharedTol = 1e-3;
+  const double kMinCellArea = 1e-3;
+
+  F2CCells result;
+  for (size_t i = 0; i < cells.size(); ++i) {
+    F2CCells swath_cell;
+    swath_cell.addGeometry(cells.getGeometry(i));
+    const Polygon ring_i = cells.getCellBorder(i);
+
+    for (size_t k = 0; k < cells.size(); ++k) {
+      if (k == i) {
+        continue;
+      }
+      const Polygon ring_k = cells.getCellBorder(k);
+      // Carve only the edges of cell_i that lie on cell_k's border: corridors
+      // exist strictly between adjacent cells, never on headland or void edges.
+      for (size_t e = 0; e + 1 < ring_i.size(); ++e) {
+        const Point a = ring_i.getGeometry(e);
+        const Point b = ring_i.getGeometry(e + 1);
+        const Point mid = (a + b) * 0.5;
+        if (ring_k.closestPointTo(a).distance(a) < kSharedTol &&
+          ring_k.closestPointTo(b).distance(b) < kSharedTol &&
+          ring_k.closestPointTo(mid).distance(mid) < kSharedTol)
+        {
+          swath_cell = swath_cell.difference(
+            Field::buffer(LineString(a, b), route_width));
+        }
+      }
+    }
+
+    for (size_t j = 0; j < swath_cell.size(); ++j) {
+      if (swath_cell.getGeometry(j).area() > kMinCellArea) {
+        result.addGeometry(swath_cell.getGeometry(j));
+      }
+    }
+  }
+
+  if (result.size() == 0) {
+    throw CoverageException(
+      "route_headland_width is too large: every sub-cell collapsed. Reduce it.");
+  }
+  return result;
+}
+
 std::vector<F2CCells> HeadlandGenerator::generateHeadlandSwaths(
   const Field & field, double operation_width,
   const opennav_coverage_msgs::msg::HeadlandMode & settings)

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <vector>
 #include <string>
 
@@ -47,13 +48,91 @@ Path PathGenerator::generatePath(
     logger_,
     "Generating path with curve: %s", toString(action_type, action_continuity_type).c_str());
   curve->setDiscretization(turn_point_distance);
-  Path path = generator_->planPath(robot_params_->getRobot(), route, *curve);
+  Path path = assemblePath(route, *curve);
 
   // Optionally thin out near-duplicate points (e.g. in turns)
   if (reduce_path_) {
     path.reduce(reduce_min_dist_);
   }
   return path;
+}
+
+Path PathGenerator::assemblePath(const F2CRoute & route, f2c::pp::TurningBase & curve)
+{
+  auto & robot = robot_params_->getRobot();
+  Path path;
+  for (size_t i = 0; i < route.sizeVectorSwaths(); ++i) {
+    const Swaths prev = (i > 0) ? route.getSwaths(i - 1) : Swaths();
+    const F2CMultiPoint connection =
+      (i < route.sizeConnections()) ? route.getConnection(i) : F2CMultiPoint();
+    appendConnection(path, prev, connection, route.getSwaths(i), curve);
+    path += generator_->planPath(robot, route.getSwaths(i), curve);
+  }
+  if (route.sizeConnections() > route.sizeVectorSwaths()) {
+    appendConnection(
+      path, route.getLastSwaths(), route.getLastConnection(), Swaths(), curve);
+  }
+  return path;
+}
+
+void PathGenerator::appendConnection(
+  Path & path, const Swaths & prev, const F2CMultiPoint & connection,
+  const Swaths & next, f2c::pp::TurningBase & curve)
+{
+  auto & robot = robot_params_->getRobot();
+  const bool has_prev = prev.size() > 0;
+  const bool has_next = next.size() > 0;
+  if (!has_prev && !has_next && connection.size() < 2) {
+    return;
+  }
+
+  std::vector<Point> pts;
+  if (has_prev) {
+    pts.push_back(prev.back().endPoint());
+  }
+  for (size_t i = 0; i < connection.size(); ++i) {
+    pts.push_back(connection[i]);
+  }
+  if (has_next) {
+    pts.push_back(next[0].startPoint());
+  }
+  if (pts.size() < 2) {
+    return;
+  }
+
+  double polyline_len = 0.0;
+  for (size_t i = 0; i + 1 < pts.size(); ++i) {
+    polyline_len += pts[i].distance(pts[i + 1]);
+  }
+  const double direct_len = pts.front().distance(pts.back());
+
+  // Near-straight hop between two swath groups: one curve (the u-turn). Boundary
+  // connections (to/from a TSP start point) fall through to keep that point.
+  if (has_prev && has_next && polyline_len < 1.3 * std::max(direct_len, 1e-6)) {
+    path += curve.createTurn(
+      robot, prev.back().endPoint(), prev.back().getOutAngle(),
+      next[0].startPoint(), next[0].getInAngle());
+    return;
+  }
+
+  // The polyline detours (e.g. around a concave notch): follow it verbatim as
+  // HL_SWATH states so the vehicle stays on the planned border/corridor track.
+  for (size_t i = 0; i + 1 < pts.size(); ++i) {
+    const double dx = pts[i + 1].getX() - pts[i].getX();
+    const double dy = pts[i + 1].getY() - pts[i].getY();
+    const double len = std::hypot(dx, dy);
+    if (len < 1e-6) {
+      continue;
+    }
+    PathState s;
+    s.point = pts[i];
+    s.angle = std::atan2(dy, dx);
+    s.len = len;
+    s.dir = f2c::types::PathDirection::FORWARD;
+    s.type = f2c::types::PathSectionType::HL_SWATH;
+    s.velocity = robot.getCruiseVel();
+    path.addState(s);
+  }
 }
 
 void PathGenerator::setPathMode(const std::string & new_mode)

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -100,6 +100,24 @@ void PathGenerator::appendConnection(
     return;
   }
 
+  // Drop attachment spikes: a bridge point past the endpoint that doubles back.
+  bool changed = true;
+  while (changed && pts.size() > 2) {
+    changed = false;
+    for (const size_t i : {size_t{1}, pts.size() - 2}) {
+      const Point & a = pts[i - 1];
+      const Point & b = pts[i];
+      const Point & c = pts[i + 1];
+      const double dot = (b.getX() - a.getX()) * (c.getX() - b.getX()) +
+        (b.getY() - a.getY()) * (c.getY() - b.getY());
+      if (dot < 0.0 && a.distance(b) < a.distance(c)) {
+        pts.erase(pts.begin() + i);
+        changed = true;
+        break;
+      }
+    }
+  }
+
   double polyline_len = 0.0;
   for (size_t i = 0; i + 1 < pts.size(); ++i) {
     polyline_len += pts[i].distance(pts[i + 1]);

--- a/opennav_coverage/src/route_generator.cpp
+++ b/opennav_coverage/src/route_generator.cpp
@@ -25,7 +25,7 @@ F2CRoute RouteGenerator::generateRoute(
   const F2CCells & travel_cells, const F2CCells & swath_cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end)
+  const std::optional<F2CPoint> & start_end_point)
 {
   RouteType action_type = toType(settings.mode);
 
@@ -51,12 +51,12 @@ F2CRoute RouteGenerator::generateRoute(
             "No valid route mode set! Options: BOUSTROPHEDON, SNAKE, SPIRAL, CUSTOM, TSP.");
   }
 
-  if (start_end && action_type != RouteType::TSP) {
+  if (start_end_point && action_type != RouteType::TSP) {
     RCLCPP_WARN(logger_, "start_pose ignored: only used in TSP route mode.");
   }
 
   RCLCPP_DEBUG(logger_, "Generating route: %s", toString(action_type).c_str());
-  return method->plan(travel_cells, swath_cells, swaths_by_cells, eff, start_end);
+  return method->plan(travel_cells, swath_cells, swaths_by_cells, eff, start_end_point);
 }
 
 void RouteGenerator::setMode(const std::string & new_mode)

--- a/opennav_coverage/src/route_generator.cpp
+++ b/opennav_coverage/src/route_generator.cpp
@@ -22,9 +22,10 @@ namespace opennav_coverage
 {
 
 F2CRoute RouteGenerator::generateRoute(
-  const F2CCells & cells, const F2CSwathsByCells & swaths_by_cells,
+  const F2CCells & travel_cells, const F2CCells & swath_cells,
+  const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end_point)
+  const std::optional<F2CPoint> & start_end)
 {
   RouteType action_type = toType(settings.mode);
 
@@ -50,12 +51,12 @@ F2CRoute RouteGenerator::generateRoute(
             "No valid route mode set! Options: BOUSTROPHEDON, SNAKE, SPIRAL, CUSTOM, TSP.");
   }
 
-  if (start_end_point && action_type != RouteType::TSP) {
+  if (start_end && action_type != RouteType::TSP) {
     RCLCPP_WARN(logger_, "start_pose ignored: only used in TSP route mode.");
   }
 
   RCLCPP_DEBUG(logger_, "Generating route: %s", toString(action_type).c_str());
-  return method->plan(cells, swaths_by_cells, eff, start_end_point);
+  return method->plan(travel_cells, swath_cells, swaths_by_cells, eff, start_end);
 }
 
 void RouteGenerator::setMode(const std::string & new_mode)

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <limits>
+#include <utility>
 #include <vector>
 
 #include "opennav_coverage/route_method.hpp"
@@ -141,25 +144,35 @@ F2CRoute TspRouteMethod::plan(
     return F2CRoute();
   }
 
-  // Visit cells in nearest-neighbor order, entering each from whichever end of
-  // its route is closer (reversing the cell route when needed), so the bridges
-  // between cells stay short instead of jumping across the field.
+  // Nearest-neighbor cell order; entry cost also penalizes heading mismatch to avoid S-maneuvers.
+  const auto angDiff = [](double a, double b) {
+      return std::fabs(std::atan2(std::sin(a - b), std::cos(a - b)));
+    };
   const auto pickNearest =
-    [&cell_routes, &remaining](const F2CPoint & from, bool & reversed) {
+    [&cell_routes, &remaining, &angDiff](
+    const F2CPoint & from, const std::optional<double> & from_angle, bool & reversed) {
       size_t best_idx = remaining[0];
-      double best_dist = std::numeric_limits<double>::max();
+      double best_cost = std::numeric_limits<double>::max();
       for (const size_t idx : remaining) {
-        const double d_fwd = from.distance(cell_routes[idx].startPoint());
-        const double d_rev = from.distance(cell_routes[idx].endPoint());
-        if (d_fwd < best_dist) {
-          best_dist = d_fwd;
-          best_idx = idx;
-          reversed = false;
-        }
-        if (d_rev < best_dist) {
-          best_dist = d_rev;
-          best_idx = idx;
-          reversed = true;
+        const auto & groups = cell_routes[idx].getVectorSwaths();
+        const F2CSwath & first_swath = groups.front().at(0);
+        const F2CSwath & last_swath = groups.back().back();
+        const std::array<std::pair<F2CPoint, double>, 2> entries = {
+          std::make_pair(cell_routes[idx].startPoint(), first_swath.getInAngle()),
+          std::make_pair(cell_routes[idx].endPoint(), last_swath.getOutAngle() + M_PI)};
+        for (size_t e = 0; e < entries.size(); ++e) {
+          const double dist = from.distance(entries[e].first);
+          double cost = dist;
+          if (from_angle && dist > 1e-6) {
+            const double bearing = (entries[e].first - from).getAngleFromPoint();
+            cost += first_swath.getWidth() *
+              (angDiff(*from_angle, bearing) + angDiff(bearing, entries[e].second));
+          }
+          if (cost < best_cost) {
+            best_cost = cost;
+            best_idx = idx;
+            reversed = (e == 1);
+          }
         }
       }
       return best_idx;
@@ -172,7 +185,7 @@ F2CRoute TspRouteMethod::plan(
       logger_,
       "Multi-cell route: start_pose picks the nearest cell; the route starts at "
       "that cell's own start, not at the exact point.");
-    current = pickNearest(*start_end, current_reversed);
+    current = pickNearest(*start_end, std::nullopt, current_reversed);
   }
 
   // Bridges follow the travel-cell pair's border graph, not a line that could cut a void.
@@ -245,7 +258,10 @@ F2CRoute TspRouteMethod::plan(
     if (remaining.empty()) {
       break;
     }
-    current = pickNearest(merged.endPoint(), current_reversed);
+    current = pickNearest(
+      merged.endPoint(),
+      last_swath ? std::optional<double>(last_swath->getOutAngle()) : std::nullopt,
+      current_reversed);
   }
   return merged;
 }

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <limits>
 #include <vector>
 
 #include "opennav_coverage/route_method.hpp"
@@ -19,21 +21,58 @@
 namespace opennav_coverage
 {
 
+namespace
+{
+
+F2CMultiPoint reversedConnection(const F2CMultiPoint & mp)
+{
+  std::vector<F2CPoint> pts;
+  pts.reserve(mp.size());
+  for (int i = static_cast<int>(mp.size()) - 1; i >= 0; --i) {
+    pts.emplace_back(mp[i]);
+  }
+  return F2CMultiPoint(pts);
+}
+
+// Reverses group order, each swath, and each connection so a cell can be entered from either end.
+F2CRoute reversedRoute(const F2CRoute & route)
+{
+  const auto & groups = route.getVectorSwaths();
+  const auto & conns = route.getConnections();
+  F2CRoute out;
+  for (int k = static_cast<int>(groups.size()) - 1; k >= 0; --k) {
+    F2CSwaths swaths = groups[k];
+    swaths.reverse();
+    for (size_t s = 0; s < swaths.size(); ++s) {
+      swaths.at(s).reverse();
+    }
+    const size_t conn_after = static_cast<size_t>(k) + 1;
+    out.addConnectedSwaths(
+      conn_after < conns.size() ? reversedConnection(conns[conn_after]) : F2CMultiPoint(),
+      swaths);
+  }
+  return out;
+}
+
+}  // namespace
+
 F2CRoute SwathOrderMethod::plan(
-  const F2CCells & cells,
+  const F2CCells & travel_cells,
+  const F2CCells & swath_cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & /*start_end_point*/)
+  const std::optional<F2CPoint> & start_end)
 {
-  // The orderers assume a single cell; multi-cell (decomposed) input breaks their
-  // ordering, so only TSP handles it. Reject rather than produce a bad route.
-  if (cells.size() > 1) {
+  (void)travel_cells;
+  (void)start_end;  // TSP-only concept; the generator already warns the user
+
+  // These orderers assume a single cell; multi-cell input breaks their ordering.
+  if (swath_cells.size() > 1) {
     throw CoverageException(
             "Non-TSP route modes are not supported with field decomposition; "
             "use route_mode TSP or disable decomposition.");
   }
 
-  // The F2C orderers operate on a single flat swath list.
   if (type_ == RouteType::SPIRAL) {
     dynamic_cast<f2c::rp::SpiralOrder *>(orderer_.get())->setSpiralSize(settings.spiral_n);
   } else if (type_ == RouteType::CUSTOM) {
@@ -50,10 +89,11 @@ F2CRoute SwathOrderMethod::plan(
 }
 
 F2CRoute TspRouteMethod::plan(
-  const F2CCells & cells,
+  const F2CCells & travel_cells,
+  const F2CCells & swath_cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end_point)
+  const std::optional<F2CPoint> & start_end)
 {
   const bool redirect_swaths = settings.tsp_redirect_swaths;
   const long int time_limit = settings.tsp_time_limit;  // NOLINT
@@ -66,51 +106,133 @@ F2CRoute TspRouteMethod::plan(
     redirect_swaths ? "true" : "false", time_limit,
     search_for_optimum ? "true" : "false", d_tol);
 
-  // One global genRoute keeps inter-cell connections along the shared borders/
-  // headland. Capped by swath count: F2C's all-pairs path matrix grows with the
-  // square of swath count and can run out of memory on large decompositions.
-  size_t total_swaths = 0;
-  for (size_t i = 0; i < swaths_by_cells.size(); ++i) {
-    total_swaths += swaths_by_cells.at(i).size();
-  }
-  if (total_swaths <= max_swaths_for_global_route_) {
+  // Single cell: one genRoute call, which honors the start/end point exactly.
+  if (swath_cells.size() <= 1) {
     f2c::rp::RoutePlannerBase rp;
-    if (start_end_point) {
-      rp.setStartAndEndPoint(*start_end_point);
+    if (start_end) {
+      rp.setStartAndEndPoint(*start_end);
     }
     return rp.genRoute(
-      cells, swaths_by_cells, false, d_tol, redirect_swaths, time_limit, search_for_optimum);
+      swath_cells, swaths_by_cells, false, d_tol, redirect_swaths, time_limit,
+      search_for_optimum);
   }
 
-  // start_end_point can't be honored per-cell, so warn and drop it in the stitched fallback
-  if (start_end_point) {
-    RCLCPP_WARN(
-      logger_,
-      "start_pose ignored: swath count exceeds max_swaths_for_global_route; route is stitched "
-      "per-cell.");
-  }
-
-  // Fallback for large decompositions: solve each cell alone and stitch the
-  // routes together with a straight-line bridge between cells.
-  F2CRoute merged;
-  for (size_t i = 0; i < cells.size(); ++i) {
-    if (i >= swaths_by_cells.size() || swaths_by_cells.at(i).size() == 0) {
+  // Multi-cell: solve each cell alone to avoid interleaving and the all-pairs path matrix.
+  std::vector<F2CRoute> cell_routes(swath_cells.size());
+  for (size_t i = 0; i < swath_cells.size() && i < swaths_by_cells.size(); ++i) {
+    if (swaths_by_cells.at(i).size() == 0) {
       continue;
     }
-    F2CCells cell(cells.getGeometry(i));
+    F2CCells cell(swath_cells.getGeometry(i));
     F2CSwathsByCells cell_swaths;
     cell_swaths.emplace_back(swaths_by_cells.at(i));
-
     f2c::rp::RoutePlannerBase rp;
-    F2CRoute cell_route = rp.genRoute(
+    cell_routes[i] = rp.genRoute(
       cell, cell_swaths, false, d_tol, redirect_swaths, time_limit, search_for_optimum);
-    if (cell_route.isEmpty()) {
-      continue;
-    }
+  }
 
-    if (!merged.isEmpty()) {
+  std::vector<size_t> remaining;
+  for (size_t i = 0; i < cell_routes.size(); ++i) {
+    if (!cell_routes[i].isEmpty()) {
+      remaining.push_back(i);
+    }
+  }
+  if (remaining.empty()) {
+    return F2CRoute();
+  }
+
+  // Visit cells in nearest-neighbor order, entering each from whichever end of
+  // its route is closer (reversing the cell route when needed), so the bridges
+  // between cells stay short instead of jumping across the field.
+  const auto pickNearest =
+    [&cell_routes, &remaining](const F2CPoint & from, bool & reversed) {
+      size_t best_idx = remaining[0];
+      double best_dist = std::numeric_limits<double>::max();
+      for (const size_t idx : remaining) {
+        const double d_fwd = from.distance(cell_routes[idx].startPoint());
+        const double d_rev = from.distance(cell_routes[idx].endPoint());
+        if (d_fwd < best_dist) {
+          best_dist = d_fwd;
+          best_idx = idx;
+          reversed = false;
+        }
+        if (d_rev < best_dist) {
+          best_dist = d_rev;
+          best_idx = idx;
+          reversed = true;
+        }
+      }
+      return best_idx;
+    };
+
+  size_t current = remaining[0];
+  bool current_reversed = false;
+  if (start_end) {
+    RCLCPP_WARN(
+      logger_,
+      "Multi-cell route: start_pose picks the nearest cell; the route starts at "
+      "that cell's own start, not at the exact point.");
+    current = pickNearest(*start_end, current_reversed);
+  }
+
+  // Bridges follow the travel-cell pair's border graph, not a line that could cut a void.
+  const auto buildBridge =
+    [&travel_cells, d_tol](
+    const F2CSwath & from_swath, const F2CSwath & to_swath,
+    const F2CPoint & from, const F2CPoint & to) {
+      F2CSwaths end_swaths;
+      end_swaths.emplace_back(from_swath);
+      end_swaths.emplace_back(to_swath);
+      F2CSwathsByCells bridge_swaths;
+      bridge_swaths.emplace_back(end_swaths);
+
+      const auto viaGraph =
+        [&bridge_swaths, d_tol, &from, &to](const F2CCells & graph_cells) {
+          std::vector<F2CPoint> pts;
+          try {
+            f2c::rp::RoutePlannerBase rp;
+            F2CGraph2D graph = rp.createShortestGraph(graph_cells, bridge_swaths, d_tol);
+            pts = graph.shortestPath(from, to);
+          } catch (const std::exception &) {
+            pts.clear();
+          }
+          return pts;
+        };
+
+      F2CCells pair_cells;
+      const Field cell_a = travel_cells.getCellWherePoint(from);
+      if (cell_a.size() > 0) {
+        pair_cells.addGeometry(cell_a);
+      }
+      const Field cell_b = travel_cells.getCellWherePoint(to);
+      if (cell_b.size() > 0) {
+        pair_cells.addGeometry(cell_b);
+      }
+
+      std::vector<F2CPoint> bridge;
+      if (pair_cells.size() > 0) {
+        bridge = viaGraph(pair_cells);
+      }
+      if (bridge.size() < 2) {
+        bridge = viaGraph(travel_cells);
+      }
+      if (bridge.size() < 2) {
+        bridge = {from, to};
+      }
+      return bridge;
+    };
+
+  F2CRoute merged;
+  std::optional<F2CSwath> last_swath;
+  while (true) {
+    remaining.erase(std::find(remaining.begin(), remaining.end(), current));
+    const F2CRoute cell_route =
+      current_reversed ? reversedRoute(cell_routes[current]) : cell_routes[current];
+    if (!merged.isEmpty() && last_swath) {
       merged.addConnection(
-        std::vector<F2CPoint>{merged.endPoint(), cell_route.startPoint()});
+        buildBridge(
+          *last_swath, cell_route.getVectorSwaths().front().at(0),
+          merged.endPoint(), cell_route.startPoint()));
     }
     const auto & vec_swaths = cell_route.getVectorSwaths();
     const auto & connections = cell_route.getConnections();
@@ -118,6 +240,12 @@ F2CRoute TspRouteMethod::plan(
       merged.addConnectedSwaths(
         k < connections.size() ? connections[k] : F2CMultiPoint(), vec_swaths[k]);
     }
+    last_swath = cell_route.getVectorSwaths().back().back();
+
+    if (remaining.empty()) {
+      break;
+    }
+    current = pickNearest(merged.endPoint(), current_reversed);
   }
   return merged;
 }

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -60,15 +60,12 @@ F2CRoute reversedRoute(const F2CRoute & route)
 }  // namespace
 
 F2CRoute SwathOrderMethod::plan(
-  const F2CCells & travel_cells,
+  const F2CCells & /*travel_cells*/,
   const F2CCells & swath_cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end)
+  const std::optional<F2CPoint> & /*start_end_point*/)
 {
-  (void)travel_cells;
-  (void)start_end;  // TSP-only concept; the generator already warns the user
-
   // These orderers assume a single cell; multi-cell input breaks their ordering.
   if (swath_cells.size() > 1) {
     throw CoverageException(
@@ -96,7 +93,7 @@ F2CRoute TspRouteMethod::plan(
   const F2CCells & swath_cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end)
+  const std::optional<F2CPoint> & start_end_point)
 {
   const bool redirect_swaths = settings.tsp_redirect_swaths;
   const long int time_limit = settings.tsp_time_limit;  // NOLINT
@@ -112,8 +109,8 @@ F2CRoute TspRouteMethod::plan(
   // Single cell: one genRoute call, which honors the start/end point exactly.
   if (swath_cells.size() <= 1) {
     f2c::rp::RoutePlannerBase rp;
-    if (start_end) {
-      rp.setStartAndEndPoint(*start_end);
+    if (start_end_point) {
+      rp.setStartAndEndPoint(*start_end_point);
     }
     return rp.genRoute(
       swath_cells, swaths_by_cells, false, d_tol, redirect_swaths, time_limit,
@@ -180,12 +177,12 @@ F2CRoute TspRouteMethod::plan(
 
   size_t current = remaining[0];
   bool current_reversed = false;
-  if (start_end) {
+  if (start_end_point) {
     RCLCPP_WARN(
       logger_,
       "Multi-cell route: start_pose picks the nearest cell; the route starts at "
       "that cell's own start, not at the exact point.");
-    current = pickNearest(*start_end, std::nullopt, current_reversed);
+    current = pickNearest(*start_end_point, std::nullopt, current_reversed);
   }
 
   // Bridges follow the travel-cell pair's border graph, not a line that could cut a void.

--- a/opennav_coverage/src/visualizer.cpp
+++ b/opennav_coverage/src/visualizer.cpp
@@ -29,12 +29,14 @@ void Visualizer::deactivate()
   headlands_pub_.reset();
   planning_field_pub_.reset();
   swaths_pub_.reset();
+  headland_swaths_pub_.reset();
 }
 
 void Visualizer::visualize(
   const Field & total_field, const Field & no_headland_field,
   const Point & ref_pt, const nav_msgs::msg::Path & nav_path,
-  const Swaths swaths, const std_msgs::msg::Header & header)
+  const Swaths swaths, const std_msgs::msg::Header & header,
+  const Path & headland_path)
 {
   // F2C strips out reference point of all data, so we need to readd it
   // so that our visualizations mirror the true transformed output
@@ -101,6 +103,28 @@ void Visualizer::visualize(
     }
 
     swaths_pub_->publish(std::move(output_swaths));
+  }
+
+  // Visualize the headland perimeter loop, if driven, in a distinct color so
+  // it's not confused with the (identically-shaped) planning_field boundary.
+  if (headland_swaths_pub_->get_subscription_count() > 0 && headland_path.size() > 0) {
+    auto output_hl = std::make_unique<visualization_msgs::msg::Marker>();
+    output_hl->header.stamp = header.stamp;
+    output_hl->header.frame_id = GLOBAL_FRAME;
+    output_hl->action = visualization_msgs::msg::Marker::ADD;
+    output_hl->type = visualization_msgs::msg::Marker::LINE_STRIP;
+    output_hl->pose.orientation.w = 1.0;
+    output_hl->scale.x = 0.4;
+    output_hl->color.r = 1.0;
+    output_hl->color.a = 1.0;
+
+    for (const auto & s : headland_path) {
+      output_hl->points.push_back(util::pointToPoint32(util::toMsg(s.point + ref_pt)));
+    }
+    output_hl->points.push_back(
+      util::pointToPoint32(util::toMsg(headland_path.back().atEnd() + ref_pt)));
+
+    headland_swaths_pub_->publish(std::move(output_hl));
   }
 }
 

--- a/opennav_coverage/src/visualizer.cpp
+++ b/opennav_coverage/src/visualizer.cpp
@@ -30,13 +30,14 @@ void Visualizer::deactivate()
   planning_field_pub_.reset();
   swaths_pub_.reset();
   headland_swaths_pub_.reset();
+  swath_cells_pub_.reset();
 }
 
 void Visualizer::visualize(
   const Field & total_field, const Field & no_headland_field,
   const Point & ref_pt, const nav_msgs::msg::Path & nav_path,
   const Swaths swaths, const std_msgs::msg::Header & header,
-  const Path & headland_path)
+  const Path & headland_path, const F2CCells & swath_cells)
 {
   // F2C strips out reference point of all data, so we need to readd it
   // so that our visualizations mirror the true transformed output
@@ -105,26 +106,62 @@ void Visualizer::visualize(
     swaths_pub_->publish(std::move(output_swaths));
   }
 
-  // Visualize the headland perimeter loop, if driven, in a distinct color so
-  // it's not confused with the (identically-shaped) planning_field boundary.
-  if (headland_swaths_pub_->get_subscription_count() > 0 && headland_path.size() > 0) {
+  // Headland perimeter loop, if driven; DELETEALL when this goal has no pass so a
+  // previous goal's marker doesn't linger.
+  if (headland_swaths_pub_->get_subscription_count() > 0) {
     auto output_hl = std::make_unique<visualization_msgs::msg::Marker>();
     output_hl->header.stamp = header.stamp;
     output_hl->header.frame_id = GLOBAL_FRAME;
-    output_hl->action = visualization_msgs::msg::Marker::ADD;
-    output_hl->type = visualization_msgs::msg::Marker::LINE_STRIP;
-    output_hl->pose.orientation.w = 1.0;
-    output_hl->scale.x = 0.4;
-    output_hl->color.r = 1.0;
-    output_hl->color.a = 1.0;
 
-    for (const auto & s : headland_path) {
-      output_hl->points.push_back(util::pointToPoint32(util::toMsg(s.point + ref_pt)));
+    if (headland_path.size() == 0) {
+      output_hl->action = visualization_msgs::msg::Marker::DELETEALL;
+    } else {
+      output_hl->action = visualization_msgs::msg::Marker::ADD;
+      output_hl->type = visualization_msgs::msg::Marker::LINE_STRIP;
+      output_hl->pose.orientation.w = 1.0;
+      output_hl->scale.x = 0.4;
+      output_hl->color.r = 1.0;
+      output_hl->color.a = 1.0;
+
+      for (const auto & s : headland_path) {
+        output_hl->points.push_back(util::pointToPoint32(util::toMsg(s.point + ref_pt)));
+      }
+      output_hl->points.push_back(
+        util::pointToPoint32(util::toMsg(headland_path.back().atEnd() + ref_pt)));
     }
-    output_hl->points.push_back(
-      util::pointToPoint32(util::toMsg(headland_path.back().atEnd() + ref_pt)));
 
     headland_swaths_pub_->publish(std::move(output_hl));
+  }
+
+  // Debug: draw the exact polygons swaths are generated from (post carving)
+  if (swath_cells_pub_->get_subscription_count() > 0) {
+    auto output_cells = std::make_unique<visualization_msgs::msg::Marker>();
+    output_cells->header.stamp = header.stamp;
+    output_cells->header.frame_id = GLOBAL_FRAME;
+
+    if (swath_cells.size() == 0) {
+      output_cells->action = visualization_msgs::msg::Marker::DELETEALL;
+    } else {
+      output_cells->action = visualization_msgs::msg::Marker::ADD;
+      output_cells->type = visualization_msgs::msg::Marker::LINE_LIST;
+      output_cells->pose.orientation.w = 1.0;
+      output_cells->scale.x = 0.2;
+      output_cells->color.g = 1.0;
+      output_cells->color.b = 1.0;
+      output_cells->color.a = 1.0;
+
+      for (size_t i = 0; i < swath_cells.size(); ++i) {
+        const Polygon border = swath_cells.getCellBorder(i);
+        for (size_t j = 0; j + 1 < border.size(); ++j) {
+          output_cells->points.push_back(
+            util::pointToPoint32(util::toMsg(border.getGeometry(j) + ref_pt)));
+          output_cells->points.push_back(
+            util::pointToPoint32(util::toMsg(border.getGeometry(j + 1) + ref_pt)));
+        }
+      }
+    }
+
+    swath_cells_pub_->publish(std::move(output_cells));
   }
 }
 

--- a/opennav_coverage/test/test_headland.cpp
+++ b/opennav_coverage/test/test_headland.cpp
@@ -138,6 +138,44 @@ TEST(HeadlandTests, TestheadlandMultiCellCollapseSkipped)
   EXPECT_GT(result.getGeometry(0).area(), 0.0);
 }
 
+TEST(HeadlandTests, TestheadlandBetweenCells)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto generator = HeadlandShim(node);
+
+  // Two 50x100 cells sharing the x=50 border, inside a 100x100 outer boundary.
+  F2CCell left(F2CLinearRing({
+      F2CPoint(0, 0), F2CPoint(50, 0), F2CPoint(50, 100), F2CPoint(0, 100), F2CPoint(0, 0)}));
+  F2CCell right(F2CLinearRing({
+      F2CPoint(50, 0), F2CPoint(100, 0), F2CPoint(100, 100),
+      F2CPoint(50, 100), F2CPoint(50, 0)}));
+  F2CCells cells;
+  cells.addGeometry(left);
+  cells.addGeometry(right);
+
+  F2CCells result = generator.generateHeadlandsBetweenCells(cells, 2.0);
+
+  EXPECT_EQ(result.size(), 2u);
+  // Only x=50 is carved (~48x100 each): total > full-border-buffer case (8832)
+  // but < the original (10000).
+  EXPECT_GT(result.area(), 9000.0);
+  EXPECT_LT(result.area(), 9999.0);
+
+  // Width larger than the cells collapses everything -> throws.
+  EXPECT_THROW(generator.generateHeadlandsBetweenCells(cells, 60.0), CoverageException);
+
+  // Cells facing each other across a void share no border, so nothing may be
+  // carved (route headland only ever goes between truly adjacent cells).
+  F2CCell far_right(F2CLinearRing({
+      F2CPoint(60, 0), F2CPoint(110, 0), F2CPoint(110, 100),
+      F2CPoint(60, 100), F2CPoint(60, 0)}));
+  F2CCells apart;
+  apart.addGeometry(left);
+  apart.addGeometry(far_right);
+  F2CCells untouched = generator.generateHeadlandsBetweenCells(apart, 2.0);
+  EXPECT_NEAR(untouched.area(), apart.area(), 1e-3);
+}
+
 TEST(HeadlandTests, TestheadlandSwathRings)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");

--- a/opennav_coverage/test/test_headland.cpp
+++ b/opennav_coverage/test/test_headland.cpp
@@ -138,6 +138,31 @@ TEST(HeadlandTests, TestheadlandMultiCellCollapseSkipped)
   EXPECT_GT(result.getGeometry(0).area(), 0.0);
 }
 
+TEST(HeadlandTests, TestheadlandSwathRings)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto generator = HeadlandShim(node);
+
+  F2CCell cell(F2CLinearRing({
+      F2CPoint(0, 0), F2CPoint(100, 0), F2CPoint(100, 100),
+      F2CPoint(0, 100), F2CPoint(0, 0)}));
+
+  opennav_coverage_msgs::msg::HeadlandMode settings;  // default width 2.0 m
+  // 2.0 / 0.7 -> 3 concentric passes, ordered outer to inner
+  auto rings = generator.generateHeadlandSwaths(cell, 0.7, settings);
+
+  EXPECT_EQ(rings.size(), 3u);
+  double prev_area = cell.area();
+  for (const auto & ring : rings) {
+    ASSERT_GT(ring.size(), 0u);
+    EXPECT_LT(ring.getGeometry(0).area(), prev_area);
+    prev_area = ring.getGeometry(0).area();
+  }
+
+  // Invalid operation width must throw rather than divide by zero
+  EXPECT_THROW(generator.generateHeadlandSwaths(cell, 0.0, settings), CoverageException);
+}
+
 TEST(HeadlandTests, TestheadlandMultiCellAllCollapseThrows)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");

--- a/opennav_coverage/test/test_path.cpp
+++ b/opennav_coverage/test/test_path.cpp
@@ -161,4 +161,38 @@ TEST(PathTests, TestpathGenerationFromF2CRoute)
   EXPECT_TRUE(std::isfinite(path.getTaskTime()));
 }
 
+TEST(PathTests, TestpathGenerationMultiCellConnections)
+{
+  // A multi-cell TSP route carries inter-cell connections; assemblePath must
+  // stitch them without dropping swaths or the connection track.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteGenerator route_gen(node);
+  PathShim generator(node, &robot_params);
+
+  F2CCells cells;
+  cells.addGeometry(F2CCell(F2CLinearRing({
+      F2CPoint(0, 0), F2CPoint(100, 0), F2CPoint(100, 100),
+      F2CPoint(0, 100), F2CPoint(0, 0)})));
+  cells.addGeometry(F2CCell(F2CLinearRing({
+      F2CPoint(100, 0), F2CPoint(200, 0), F2CPoint(200, 100),
+      F2CPoint(100, 100), F2CPoint(100, 0)})));
+
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode rt_settings;
+  rt_settings.mode = "TSP";
+  rt_settings.tsp_time_limit = 1;
+  F2CRoute route = route_gen.generateRoute(cells, sbc, rt_settings);
+  ASSERT_FALSE(route.isEmpty());
+  ASSERT_GE(route.sizeConnections(), 1u);
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  EXPECT_GT(path.size(), 0u);
+  EXPECT_TRUE(std::isfinite(path.getTaskTime()));
+}
+
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_route.cpp
+++ b/opennav_coverage/test/test_route.cpp
@@ -71,6 +71,19 @@ static F2CCells makeSquareCells(double s)
   return cells;
 }
 
+// Two s x s cells sharing the x=s edge, to exercise the multi-cell TSP stitch.
+static F2CCells makeTwoAdjacentCells(double s)
+{
+  F2CCells cells;
+  cells.addGeometry(F2CCell(F2CLinearRing({
+      F2CPoint(0.0, 0.0), F2CPoint(s, 0.0), F2CPoint(s, s),
+      F2CPoint(0.0, s), F2CPoint(0.0, 0.0)})));
+  cells.addGeometry(F2CCell(F2CLinearRing({
+      F2CPoint(s, 0.0), F2CPoint(2 * s, 0.0), F2CPoint(2 * s, s),
+      F2CPoint(s, s), F2CPoint(s, 0.0)})));
+  return cells;
+}
+
 TEST(RouteTests, TestrouteUtils)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
@@ -296,22 +309,52 @@ TEST(RouteTests, TestNonTSPStartPointIgnored)
   EXPECT_NEAR(without.length(), with.length(), 1e-6);
 }
 
-TEST(RouteTests, TestTSPStitchIgnoresStartPoint)
+TEST(RouteTests, TestTSPMultiCellStitch)
 {
-  // The stitched fallback drops the start point but still produces a valid route
+  // Two cells route per-cell and stitch: every cell stays contiguous, swaths are
+  // preserved, and at least one inter-cell connection (bridge) is produced.
   auto node = std::make_shared<rclcpp::Node>("test_node");
   RobotParams robot_params(node);
   SwathGenerator swath_gen(node, &robot_params);
   RouteShim generator(node);
 
-  F2CCells cells = makeSquareCells(100.0);
+  F2CCells cells = makeTwoAdjacentCells(100.0);
   opennav_coverage_msgs::msg::SwathMode sw_settings;
   F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
-
-  generator.setMaxSwathsForGlobalRoute(0);  // force the stitched fallback
+  ASSERT_GE(sbc.size(), 2u);  // one swath group per cell
 
   opennav_coverage_msgs::msg::RouteMode settings;
   settings.mode = "TSP";
+  settings.tsp_time_limit = 1;
+  F2CRoute route = generator.generateRoute(cells, sbc, settings);
+
+  EXPECT_FALSE(route.isEmpty());
+  EXPECT_GE(route.sizeVectorSwaths(), 2u);
+  EXPECT_GE(route.sizeConnections(), 1u);
+
+  size_t total_out = 0;
+  for (size_t i = 0; i < route.sizeVectorSwaths(); ++i) {
+    total_out += route.getVectorSwaths()[i].size();
+  }
+  EXPECT_EQ(sbc.sizeTotal(), total_out);
+}
+
+TEST(RouteTests, TestTSPMultiCellStartPoint)
+{
+  // On the multi-cell path the exact start point isn't honored (the nearest cell
+  // is chosen and warned), but the route stays valid.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeTwoAdjacentCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "TSP";
+  settings.tsp_time_limit = 1;
   F2CRoute route = generator.generateRoute(cells, sbc, settings, F2CPoint(0.0, 0.0));
   EXPECT_FALSE(route.isEmpty());
 }

--- a/opennav_coverage/test/test_server.cpp
+++ b/opennav_coverage/test/test_server.cpp
@@ -41,14 +41,31 @@ public:
   ServerShim()
   : CoverageServer()
   {}
+  ~ServerShim()
+  {
+    // Deactivate blocks until the worker thread finishes, so members aren't destroyed under it.
+    if (activated_) {
+      rclcpp_lifecycle::State state;
+      this->on_deactivate(state);
+      this->on_cleanup(state);
+    }
+  }
   void configure(const rclcpp_lifecycle::State & state)
   {
     this->on_configure(state);
     cartesian_frame_ = false;  // Test files in GPS
   }
   void setCartesianFrame(bool v) {cartesian_frame_ = v;}
-  void activate(const rclcpp_lifecycle::State & state) {this->on_activate(state);}
-  void deactivate(const rclcpp_lifecycle::State & state) {this->on_deactivate(state);}
+  void activate(const rclcpp_lifecycle::State & state)
+  {
+    this->on_activate(state);
+    activated_ = true;
+  }
+  void deactivate(const rclcpp_lifecycle::State & state)
+  {
+    this->on_deactivate(state);
+    activated_ = false;
+  }
   void cleanup(const rclcpp_lifecycle::State & state) {this->on_cleanup(state);}
   void shutdown(const rclcpp_lifecycle::State & state) {this->on_shutdown(state);}
 
@@ -56,6 +73,9 @@ public:
   {
     return validateGoal(req);
   }
+
+private:
+  bool activated_{false};
 };
 
 TEST(ServerTest, LifecycleTest)

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -538,8 +538,8 @@ TEST(UtilsTests, TesttoNavPathMsgHLSwathVelocity)
 
   EXPECT_EQ(nav_path.poses.size(), vels.size());
   EXPECT_EQ(nav_path.poses.size(), dirs.size());
-  // HL_SWATH state: velocity=1.5, direction=FORWARD, passes through as one point
-  // (discretizeSwath does not densify HL_SWATH, only SWATH)
+  // HL_SWATH state: velocity=1.5, direction=FORWARD. Now densified like SWATH
+  // (discretizeSwathLike splits HL_SWATH too), so every sub-point keeps vel/dir.
   EXPECT_NEAR(vels[0], 1.5, 1e-6);
   EXPECT_FALSE(dirs[0]);
   // TURN state: velocity=0.5, direction=BACKWARD
@@ -578,6 +578,53 @@ TEST(UtilsTests, TesttoNavPathMsgDensifyVelocitySizeMatch)
   // SWATH poses are forward; TURN poses are backward
   EXPECT_FALSE(dirs[0]);
   EXPECT_TRUE(dirs.back());
+}
+
+// HL_SWATH must be densified, not passed through as a single waypoint.
+TEST(UtilsTests, TesttoNavPathMsgHLSwathDensified)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState hl_swath;
+  hl_swath.type = f2c::types::PathSectionType::HL_SWATH;
+  hl_swath.point = Point(0.0, 0.0);
+  hl_swath.len = 1.0;
+  hl_swath.angle = 0.0;
+  hl_swath.velocity = 1.0;
+  hl_swath.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(hl_swath);
+
+  F2CField field;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f);
+
+  // len 1.0 at 0.1 spacing -> ~10 sub-points
+  EXPECT_GT(nav_path.poses.size(), 5u);
+}
+
+// Headland perimeter loop is built from a field boundary as HL_SWATH states,
+// starting at the boundary vertex closest to the given anchor.
+TEST(UtilsTests, TesttoHeadlandPerimeterPath)
+{
+  F2CLinearRing ring;
+  ring.addPoint(0.0, 0.0);
+  ring.addPoint(10.0, 0.0);
+  ring.addPoint(10.0, 10.0);
+  ring.addPoint(0.0, 10.0);
+  ring.addPoint(0.0, 0.0);
+  Field area(ring);
+
+  // Anchor closest to (10, 10) -> loop should start there.
+  Path path = util::toHeadlandPerimeterPath(area, 1.0, Point(9.0, 9.0));
+
+  EXPECT_EQ(path.size(), 4u);
+  for (const auto & s : path.getStates()) {
+    EXPECT_EQ(s.type, f2c::types::PathSectionType::HL_SWATH);
+    EXPECT_NEAR(s.velocity, 1.0, 1e-6);
+  }
+  EXPECT_NEAR(path[0].point.getX(), 10.0, 1e-6);
+  EXPECT_NEAR(path[0].point.getY(), 10.0, 1e-6);
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage_demo/params/rviz_config.rviz
+++ b/opennav_coverage_demo/params/rviz_config.rviz
@@ -616,6 +616,32 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /coverage_server/swaths
       Value: true
+    - Class: rviz_default_plugins/Marker
+      Enabled: true
+      Name: HeadlandSwaths
+      Namespaces:
+        "": true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /coverage_server/headland_swaths
+      Value: true
+    - Class: rviz_default_plugins/Marker
+      Enabled: true
+      Name: SwathCells
+      Namespaces:
+        "": true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /coverage_server/swath_cells
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/opennav_coverage_demo/params/rviz_config.rviz
+++ b/opennav_coverage_demo/params/rviz_config.rviz
@@ -629,19 +629,6 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /coverage_server/headland_swaths
       Value: true
-    - Class: rviz_default_plugins/Marker
-      Enabled: false
-      Name: SwathCells
-      Namespaces:
-        "": true
-      Topic:
-        Depth: 5
-        Durability Policy: Volatile
-        Filter size: 10
-        History Policy: Keep Last
-        Reliability Policy: Reliable
-        Value: /coverage_server/swath_cells
-      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/opennav_coverage_demo/params/rviz_config.rviz
+++ b/opennav_coverage_demo/params/rviz_config.rviz
@@ -630,7 +630,7 @@ Visualization Manager:
         Value: /coverage_server/headland_swaths
       Value: true
     - Class: rviz_default_plugins/Marker
-      Enabled: true
+      Enabled: false
       Name: SwathCells
       Namespaces:
         "": true
@@ -641,7 +641,7 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /coverage_server/swath_cells
-      Value: true
+      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -27,6 +27,14 @@ opennav_coverage_msgs/PathMode path_mode
 bool use_start_pose False
 opennav_coverage_msgs/Coordinate start_pose
 
+# Optional: also cover the headland ring area ("drive the headland").
+bool generate_headland_swaths False
+# True: drive the headland before the inner coverage; False: after it
+bool headland_first False
+# False: a single perimeter pass. True: concentric passes spaced by the
+# operation width to fully sweep the headland band (count = width / operation_width)
+bool headland_full_coverage False
+
 ---
 #result definition
 

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -7,6 +7,9 @@ bool generate_headland True
 bool generate_route True
 bool generate_path True
 
+# Decomposition only: corridor width on cells' shared borders. 0 = operation width.
+float32 route_headland_width 0.0
+
 # The field specification to use.
 # If using polygons, bounding polygon must be first, followed by inner cutouts
 # Both must specify if the data is cartesian or GPS coordinates


### PR DESCRIPTION
## Summary

Every change is opt-in or behavior-preserving by default, so a request that doesn't
decompose the field (or leaves the new fields unset) plans exactly as before.

1. Multi-cell TSP routing (per-cell solve + stitch)
2. Route corridors only between adjacent cells (`route_headland_width`)
3. Path follows route connections when they detour
4. Optional headland driving (`generate_headland_swaths`)
5. Non-TSP + decomposition rejected early; dynamic turn params
6. test_server teardown fix

## 1. Multi-cell TSP routing

With decomposition, the field becomes several cells and a single global
`genRoute` both interleaves swaths across cells and builds F2C's all-pairs path
matrix, which grows with the square of the swath count and can run out of memory
on large fields.

Instead:

- **Single cell:** one `genRoute` call, which still honors the start/end point
  exactly.
- **Multi-cell:** each cell is solved on its own, then the per-cell routes are
  stitched in nearest-neighbor order. Each cell is entered from whichever end is
  cheaper (with a heading-mismatch penalty so the entry doesn't force an
  S-maneuver), and the bridge between two cells follows the shared border graph
  of that travel-cell pair, so it detours around voids instead of cutting a
  straight line through them.

## 2. Route corridors between adjacent cells

`route_headland_width` (default `0.0` = operation width) carves a travel
corridor **only** on borders shared by two adjacent decomposed cells. Edges that
already have a headland are left untouched — a corridor is only ever added
between two cells, never on the field boundary.

## 3. Path follows route connections

F2C's path planner drops connections whose endpoints are near a swath end, which
erased the inter-cell / around-void travel from `nav_path`. The path generator
now follows those connections (as `HL_SWATH` sections) so the detour actually
appears in the output path.

## 4. Optional headland driving

Adds goal fields to optionally cover the headland ring ("drive the headland"):

```
bool generate_headland_swaths False
bool headland_first          False   # drive headland before inner coverage (else after)
bool headland_full_coverage  False   # concentric band sweep (else a single perimeter pass)
```

All default false, so headland coverage is off unless requested.
`default_generate_headland_swaths` is also exposed as a parameter.

## 5. Rejections and dynamic params

- Non-TSP route modes (BOUSTROPHEDON/SNAKE/SPIRAL/CUSTOM) don't have a
  cross-cell ordering, so combining them with decomposition is rejected early
  with a clear error instead of producing a bad route.
- `min_turning_radius`, `linear_curv_change`, and
  `default_generate_headland_swaths` are now dynamic parameters.

## 6. test_server teardown fix

Tearing the server down while the action worker was still running could corrupt
the heap and segfault the test. Teardown now waits for the worker to finish.
