### PR TITLE
Field decomposition: route corridors between adjacent cells and optional headland driving

### DIFF
--- a/opennav_coverage/include/opennav_coverage/coverage_server.hpp
+++ b/opennav_coverage/include/opennav_coverage/coverage_server.hpp
@@ -132,6 +132,7 @@ protected:
   std::unique_ptr<Visualizer> visualizer_;
   bool cartesian_frame_;
   bool default_generate_decomp_{false};
+  bool default_generate_headland_swaths_{false};
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/include/opennav_coverage/headland_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/headland_generator.hpp
@@ -75,6 +75,16 @@ public:
     const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings);
 
   /**
+   * @brief Carve a route corridor only on the borders cells actually share,
+   *        leaving edges facing the outer boundary or a void untouched.
+   * @param cells Decomposed sub-cells (share internal borders)
+   * @param route_width Corridor width carved along each shared border
+   * @return Swath cells carved only on their internal borders
+   */
+  F2CCells generateHeadlandsBetweenCells(
+    const F2CCells & cells, double route_width);
+
+  /**
    * @brief Generate concentric rings that fully sweep the headland band.
    *        Pass count is derived from the headland width and the operation
    *        width (round(width / operation_width), min 1).

--- a/opennav_coverage/include/opennav_coverage/headland_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/headland_generator.hpp
@@ -15,6 +15,7 @@
 #ifndef OPENNAV_COVERAGE__HEADLAND_GENERATOR_HPP_
 #define OPENNAV_COVERAGE__HEADLAND_GENERATOR_HPP_
 
+#include <cmath>
 #include <vector>
 #include <string>
 
@@ -72,6 +73,19 @@ public:
    */
   F2CCells generateHeadlands(
     const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings);
+
+  /**
+   * @brief Generate concentric rings that fully sweep the headland band.
+   *        Pass count is derived from the headland width and the operation
+   *        width (round(width / operation_width), min 1).
+   * @param field Full field (before headland removal)
+   * @param operation_width Spacing between rings
+   * @param settings Action request information (headland mode/width)
+   * @return Rings ordered outer to inner; each F2CCells is one pass
+   */
+  std::vector<F2CCells> generateHeadlandSwaths(
+    const Field & field, double operation_width,
+    const opennav_coverage_msgs::msg::HeadlandMode & settings);
 
   /**
    * @brief Sets the mode manually of the Headland for dynamic parameters

--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -110,6 +110,21 @@ public:
     const std::optional<F2CPoint> & start_end_point = std::nullopt);
 
   /**
+   * @brief Whether the request (or the default it falls back to) is TSP.
+   *        Used to reject non-TSP + decomposition before any geometry work.
+   * @param settings Action request information
+   * @return true when the route mode resolves to TSP
+   */
+  bool resolvesToTsp(const opennav_coverage_msgs::msg::RouteMode & settings)
+  {
+    RouteType type = toType(settings.mode);
+    if (type == RouteType::UNKNOWN) {
+      type = default_type_;
+    }
+    return type == RouteType::TSP;
+  }
+
+  /**
    * @brief Sets the mode manually of the Route for dynamic parameters
    * @param mode String for mode to use
    */

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -15,6 +15,7 @@
 #ifndef OPENNAV_COVERAGE__UTILS_HPP_
 #define OPENNAV_COVERAGE__UTILS_HPP_
 
+#include <cmath>
 #include <vector>
 #include <string>
 #include <algorithm>
@@ -229,6 +230,86 @@ inline opennav_coverage_msgs::msg::PathComponents toCoveragePathMsg(
 }
 
 /**
+ * @brief Build a drivable HL_SWATH loop around a field boundary, rotated to start
+ * at the vertex closest to `anchor` (the route's first point) to minimize the
+ * jump when spliced onto the coverage path. Density added later by discretizeSwathLike.
+ * @param area Field/cell whose exterior boundary is driven (e.g. field_no_headland)
+ * @param velocity Cruise velocity to tag each state with
+ * @param anchor Point the loop's start/end should be nearest to
+ * @return Path of HL_SWATH states (empty if the boundary has < 2 points)
+ */
+inline Path toHeadlandPerimeterPath(
+  const Field & area, double velocity, const Point & anchor)
+{
+  Path path;
+  const Polygon ring = area.getExteriorRing();  // closed boundary loop (first == last point)
+  const size_t n = ring.size();
+  if (n < 2) {
+    return path;
+  }
+  const size_t n_unique = n - 1;  // exclude the duplicated closing point
+
+  size_t start_idx = 0;
+  double best_dist2 = 0.0;
+  for (size_t i = 0; i < n_unique; ++i) {
+    const Point p = ring.getGeometry(i);
+    const double dx = p.getX() - anchor.getX();
+    const double dy = p.getY() - anchor.getY();
+    const double d2 = dx * dx + dy * dy;
+    if (i == 0 || d2 < best_dist2) {
+      best_dist2 = d2;
+      start_idx = i;
+    }
+  }
+
+  for (size_t k = 0; k < n_unique; ++k) {
+    const Point p0 = ring.getGeometry((start_idx + k) % n_unique);
+    const Point p1 = ring.getGeometry((start_idx + k + 1) % n_unique);
+    const double dx = p1.getX() - p0.getX();
+    const double dy = p1.getY() - p0.getY();
+    PathState s;
+    s.point = p0;
+    s.angle = std::atan2(dy, dx);
+    s.len = std::hypot(dx, dy);
+    s.dir = f2c::types::PathDirection::FORWARD;
+    s.type = f2c::types::PathSectionType::HL_SWATH;
+    s.velocity = velocity;
+    path.addState(s);
+  }
+  return path;
+}
+
+/**
+ * @brief Like F2C Path::discretizeSwath but also splits HL_SWATH states, so
+ * headland passes become dense followable segments. F2C's discretizeSwath only
+ * subdivides SWATH; HL_SWATH would otherwise pass through as a single waypoint.
+ * @param path Path to densify
+ * @param step_size Max spacing between emitted points
+ * @return Densified path
+ */
+inline Path discretizeSwathLike(const Path & path, double step_size)
+{
+  using f2c::types::PathSectionType;
+  Path out;
+  const double step = step_size > 0.0 ? step_size : 0.1;
+  for (const auto & s : path.getStates()) {
+    if (s.type == PathSectionType::SWATH || s.type == PathSectionType::HL_SWATH) {
+      double n_steps = std::max(1.0, std::round(std::fabs(s.len / step)));
+      Point start2end = s.atEnd() - s.point;
+      for (double j = 0.0; j < n_steps; j += 1.0) {
+        PathState state = s;
+        state.point = s.point + start2end * (j / n_steps);
+        state.len /= n_steps;
+        out.addState(state);
+      }
+    } else {
+      out.addState(s);
+    }
+  }
+  return out;
+}
+
+/**
  * @brief Converts full path to nav_msgs/path message for action client, visualization
  * and use in direct-sending to a controller to replace the planner server. Interpolates
  * the F2C path to make it dense for following semantics.
@@ -263,8 +344,9 @@ inline nav_msgs::msg::Path toNavPathMsg(
     path.moveTo(field.getRefPoint());
   }
 
-  // discretizeSwath splits only SWATH states at step_size intervals
-  path = path.discretizeSwath(static_cast<double>(pt_dist));
+  // Split SWATH and HL_SWATH states at step_size intervals (F2C's discretizeSwath
+  // splits only SWATH, leaving headland passes as single waypoints).
+  path = discretizeSwathLike(path, static_cast<double>(pt_dist));
 
   // Reserve up front so the population loop below doesn't reallocate.
   const auto n = path.size();

--- a/opennav_coverage/include/opennav_coverage/visualizer.hpp
+++ b/opennav_coverage/include/opennav_coverage/visualizer.hpp
@@ -56,6 +56,9 @@ public:
     swaths_pub_ = rclcpp::create_publisher<visualization_msgs::msg::Marker>(
       node->get_node_topics_interface(),
       "coverage_server/swaths", rclcpp::QoS(1));
+    headland_swaths_pub_ = rclcpp::create_publisher<visualization_msgs::msg::Marker>(
+      node->get_node_topics_interface(),
+      "coverage_server/headland_swaths", rclcpp::QoS(1));
   }
 
   void deactivate();
@@ -63,12 +66,14 @@ public:
   void visualize(
     const Field & total_field, const Field & no_headland_field,
     const Point & ref_pt, const nav_msgs::msg::Path & path,
-    const Swaths swaths, const std_msgs::msg::Header & header);
+    const Swaths swaths, const std_msgs::msg::Header & header,
+    const Path & headland_path = Path());
 
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr nav_plan_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr headlands_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr planning_field_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr swaths_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr headland_swaths_pub_;
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/include/opennav_coverage/visualizer.hpp
+++ b/opennav_coverage/include/opennav_coverage/visualizer.hpp
@@ -59,6 +59,9 @@ public:
     headland_swaths_pub_ = rclcpp::create_publisher<visualization_msgs::msg::Marker>(
       node->get_node_topics_interface(),
       "coverage_server/headland_swaths", rclcpp::QoS(1));
+    swath_cells_pub_ = rclcpp::create_publisher<visualization_msgs::msg::Marker>(
+      node->get_node_topics_interface(),
+      "coverage_server/swath_cells", rclcpp::QoS(1));
   }
 
   void deactivate();
@@ -67,13 +70,15 @@ public:
     const Field & total_field, const Field & no_headland_field,
     const Point & ref_pt, const nav_msgs::msg::Path & path,
     const Swaths swaths, const std_msgs::msg::Header & header,
-    const Path & headland_path = Path());
+    const Path & headland_path = Path(),
+    const F2CCells & swath_cells = F2CCells());
 
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr nav_plan_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr headlands_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr planning_field_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr swaths_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr headland_swaths_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr swath_cells_pub_;
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -206,9 +206,8 @@ void CoverageServer::computeCoveragePath()
     F2CCells route_cells;
     F2CCells swath_cells;
     if (do_decomp) {
-      // Headland-first: remove the headland from the whole field, decompose that into
-      // border-sharing cells (the travel graph), then remove the headland again per
-      // cell for the swaths, so connections run along the shared headland.
+      // Headland-first: remove the headland once from the whole field, then
+      // decompose that into border-sharing cells (the travel graph).
       Field travel_ring = field;
       if (goal->generate_headland) {
         travel_ring = headland_gen_->generateHeadlands(field, goal->headland_mode);
@@ -217,8 +216,14 @@ void CoverageServer::computeCoveragePath()
       F2CCells travel_ring_cells;
       travel_ring_cells.addGeometry(travel_ring);
       route_cells = decomp_gen_->decompose(travel_ring_cells, goal->decomp_mode);
-      swath_cells = goal->generate_headland ?
-        headland_gen_->generateHeadlands(route_cells, goal->headland_mode) : route_cells;
+      if (!goal->generate_headland) {
+        swath_cells = route_cells;
+      } else {
+        // Headland already removed before decomposing; only carve the inter-cell corridor here.
+        const double route_w = goal->route_headland_width > 0.0 ?
+          goal->route_headland_width : robot_params_->getOperationWidth();
+        swath_cells = headland_gen_->generateHeadlandsBetweenCells(route_cells, route_w);
+      }
     } else {
       // No decomposition: remove the headland from the single field cell
       if (goal->generate_headland) {
@@ -316,7 +321,7 @@ void CoverageServer::computeCoveragePath()
     visualizer_->visualize(
       field, field_no_headland, master_field.getRefPoint(),
       util::toCartesianNavPathMsg(path, header, path_gen_->getTurnPointDistance()),
-      swaths, header, headland_path);
+      swaths, header, headland_path, swath_cells);
     action_server_->succeeded_current(result);
   } catch (CoverageException & e) {
     RCLCPP_ERROR(get_logger(), "Invalid mode set: %s", e.what());

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -48,6 +48,10 @@ CoverageServer::on_configure(const rclcpp_lifecycle::State & /*state*/)
     node, "default_generate_decomp", rclcpp::ParameterValue(false));
   get_parameter("default_generate_decomp", default_generate_decomp_);
 
+  nav2::declare_parameter_if_not_declared(
+    node, "default_generate_headland_swaths", rclcpp::ParameterValue(false));
+  get_parameter("default_generate_headland_swaths", default_generate_headland_swaths_);
+
   // If in GPS coordinates, we must convert to a CRS to compute coverage
   // Then, reconvert back to GPS for the user.
   nav2::declare_parameter_if_not_declared(
@@ -234,6 +238,16 @@ void CoverageServer::computeCoveragePath()
     header.stamp = now();
     header.frame_id = frame_id;
     Path path;
+    Path headland_path;  // kept for visualization after being spliced into path
+    // Optional: also drive the headland perimeter; needs the full route+path pipeline.
+    const bool do_headland_swaths =
+      goal->generate_headland_swaths || default_generate_headland_swaths_;
+    if (do_headland_swaths && !(goal->generate_route && goal->generate_path)) {
+      RCLCPP_WARN(
+        get_logger(),
+        "generate_headland_swaths needs generate_route and generate_path; "
+        "skipping the headland perimeter pass.");
+    }
     if (goal->generate_route) {
       std::optional<F2CPoint> start_end_point;
       if (goal->use_start_pose) {
@@ -250,6 +264,34 @@ void CoverageServer::computeCoveragePath()
       // Converts UTM back to GPS, if necessary, for action returns
       if (goal->generate_path) {
         path = path_gen_->generatePath(route, goal->path_mode);
+
+        // Prepend/append the headland pass(es); loops start near the route to minimize the jump.
+        if (do_headland_swaths) {
+          const double cruise_vel = robot_params_->getRobot().getCruiseVel();
+          if (goal->headland_full_coverage) {
+            // Concentric passes (outer to inner) sweeping the whole band
+            const auto rings = headland_gen_->generateHeadlandSwaths(
+              field, robot_params_->getOperationWidth(), goal->headland_mode);
+            for (const auto & ring : rings) {
+              for (size_t c = 0; c < ring.size(); ++c) {
+                headland_path += util::toHeadlandPerimeterPath(
+                  ring.getGeometry(c), cruise_vel, path[0].point);
+              }
+            }
+          } else {
+            // Single perimeter pass along the headland's inner boundary
+            headland_path = util::toHeadlandPerimeterPath(
+              field_no_headland, cruise_vel, path[0].point);
+          }
+          if (goal->headland_first) {
+            Path combined = headland_path;
+            combined += path;
+            path = combined;
+          } else {
+            path += headland_path;
+          }
+        }
+
         result->coverage_path =
           util::toCoveragePathMsg(path, master_field, header, cartesian_frame_);
         result->nav_path = util::toNavPathMsg(
@@ -274,7 +316,7 @@ void CoverageServer::computeCoveragePath()
     visualizer_->visualize(
       field, field_no_headland, master_field.getRefPoint(),
       util::toCartesianNavPathMsg(path, header, path_gen_->getTurnPointDistance()),
-      swaths, header);
+      swaths, header, headland_path);
     action_server_->succeeded_current(result);
   } catch (CoverageException & e) {
     RCLCPP_ERROR(get_logger(), "Invalid mode set: %s", e.what());
@@ -344,6 +386,8 @@ CoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramet
         route_gen_->setTspSearchForOptimum(parameter.as_bool());
       } else if (name == "default_reduce_path") {
         path_gen_->setReducePath(parameter.as_bool());
+      } else if (name == "default_generate_headland_swaths") {
+        default_generate_headland_swaths_ = parameter.as_bool();
       }
     } else if (type == ParameterType::PARAMETER_INTEGER) {
       if (name == "default_spiral_n") {

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -200,6 +200,13 @@ void CoverageServer::computeCoveragePath()
     // (1) Build the cells to cover: remove the headland, optionally decomposing first
     const bool do_decomp = goal->generate_decomp || default_generate_decomp_;
 
+    // Reject non-TSP+decomp up front; the deep check only fires after all the geometry work.
+    if (do_decomp && goal->generate_route && !route_gen_->resolvesToTsp(goal->route_mode)) {
+      throw CoverageException(
+              "Non-TSP route modes are not supported with field decomposition; "
+              "use route_mode TSP or disable decomposition.");
+    }
+
     Field field_no_headland = field;
     // route_cells: travel graph for the route planner. swath_cells: cells swaths
     // are generated from. Differ only when decomposing with a headland.
@@ -365,6 +372,12 @@ CoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramet
       } else if (name == "operation_width") {
         auto & robot = robot_params_->getRobot();
         robot.setCovWidth(parameter.as_double());
+      } else if (name == "min_turning_radius") {
+        auto & robot = robot_params_->getRobot();
+        robot.setMinTurningRadius(parameter.as_double());
+      } else if (name == "linear_curv_change") {
+        auto & robot = robot_params_->getRobot();
+        robot.setMaxDiffCurv(parameter.as_double());
       }
     } else if (type == ParameterType::PARAMETER_STRING) {
       if (name == "default_headland_type") {

--- a/opennav_coverage/src/headland_generator.cpp
+++ b/opennav_coverage/src/headland_generator.cpp
@@ -80,6 +80,27 @@ F2CCells HeadlandGenerator::generateHeadlands(
   return result;
 }
 
+std::vector<F2CCells> HeadlandGenerator::generateHeadlandSwaths(
+  const Field & field, double operation_width,
+  const opennav_coverage_msgs::msg::HeadlandMode & settings)
+{
+  if (operation_width <= 0.0) {
+    throw CoverageException(
+      "Operation width must be > 0 to sweep the headland band (set operation_width).");
+  }
+
+  double width = 0.0;
+  HeadlandGeneratorPtr generator = resolveGenerator(settings, width);
+
+  // Number of passes needed to sweep the band at operation-width spacing
+  int n_swaths = static_cast<int>(std::round(width / operation_width));
+  if (n_swaths < 1) {
+    n_swaths = 1;
+  }
+
+  return generator->generateHeadlandSwaths(Fields(field), operation_width, n_swaths, true);
+}
+
 void HeadlandGenerator::setMode(const std::string & new_mode)
 {
   default_type_ = toType(new_mode);

--- a/opennav_coverage/src/headland_generator.cpp
+++ b/opennav_coverage/src/headland_generator.cpp
@@ -80,6 +80,59 @@ F2CCells HeadlandGenerator::generateHeadlands(
   return result;
 }
 
+F2CCells HeadlandGenerator::generateHeadlandsBetweenCells(
+  const F2CCells & cells, double route_width)
+{
+  if (route_width <= 0.0) {
+    throw CoverageException("route_headland_width must be > 0 to carve inter-cell corridors.");
+  }
+
+  // kMinCellArea drops slivers left by carving: F2C's unchecked geometry casts
+  // corrupt memory on degenerate (near-zero-area) polygons.
+  const double kSharedTol = 1e-3;
+  const double kMinCellArea = 1e-3;
+
+  F2CCells result;
+  for (size_t i = 0; i < cells.size(); ++i) {
+    F2CCells swath_cell;
+    swath_cell.addGeometry(cells.getGeometry(i));
+    const Polygon ring_i = cells.getCellBorder(i);
+
+    for (size_t k = 0; k < cells.size(); ++k) {
+      if (k == i) {
+        continue;
+      }
+      const Polygon ring_k = cells.getCellBorder(k);
+      // Carve only the edges of cell_i that lie on cell_k's border: corridors
+      // exist strictly between adjacent cells, never on headland or void edges.
+      for (size_t e = 0; e + 1 < ring_i.size(); ++e) {
+        const Point a = ring_i.getGeometry(e);
+        const Point b = ring_i.getGeometry(e + 1);
+        const Point mid = (a + b) * 0.5;
+        if (ring_k.closestPointTo(a).distance(a) < kSharedTol &&
+          ring_k.closestPointTo(b).distance(b) < kSharedTol &&
+          ring_k.closestPointTo(mid).distance(mid) < kSharedTol)
+        {
+          swath_cell = swath_cell.difference(
+            Field::buffer(LineString(a, b), route_width));
+        }
+      }
+    }
+
+    for (size_t j = 0; j < swath_cell.size(); ++j) {
+      if (swath_cell.getGeometry(j).area() > kMinCellArea) {
+        result.addGeometry(swath_cell.getGeometry(j));
+      }
+    }
+  }
+
+  if (result.size() == 0) {
+    throw CoverageException(
+      "route_headland_width is too large: every sub-cell collapsed. Reduce it.");
+  }
+  return result;
+}
+
 std::vector<F2CCells> HeadlandGenerator::generateHeadlandSwaths(
   const Field & field, double operation_width,
   const opennav_coverage_msgs::msg::HeadlandMode & settings)

--- a/opennav_coverage/src/visualizer.cpp
+++ b/opennav_coverage/src/visualizer.cpp
@@ -29,12 +29,14 @@ void Visualizer::deactivate()
   headlands_pub_.reset();
   planning_field_pub_.reset();
   swaths_pub_.reset();
+  headland_swaths_pub_.reset();
 }
 
 void Visualizer::visualize(
   const Field & total_field, const Field & no_headland_field,
   const Point & ref_pt, const nav_msgs::msg::Path & nav_path,
-  const Swaths swaths, const std_msgs::msg::Header & header)
+  const Swaths swaths, const std_msgs::msg::Header & header,
+  const Path & headland_path)
 {
   // F2C strips out reference point of all data, so we need to readd it
   // so that our visualizations mirror the true transformed output
@@ -101,6 +103,28 @@ void Visualizer::visualize(
     }
 
     swaths_pub_->publish(std::move(output_swaths));
+  }
+
+  // Visualize the headland perimeter loop, if driven, in a distinct color so
+  // it's not confused with the (identically-shaped) planning_field boundary.
+  if (headland_swaths_pub_->get_subscription_count() > 0 && headland_path.size() > 0) {
+    auto output_hl = std::make_unique<visualization_msgs::msg::Marker>();
+    output_hl->header.stamp = header.stamp;
+    output_hl->header.frame_id = GLOBAL_FRAME;
+    output_hl->action = visualization_msgs::msg::Marker::ADD;
+    output_hl->type = visualization_msgs::msg::Marker::LINE_STRIP;
+    output_hl->pose.orientation.w = 1.0;
+    output_hl->scale.x = 0.4;
+    output_hl->color.r = 1.0;
+    output_hl->color.a = 1.0;
+
+    for (const auto & s : headland_path) {
+      output_hl->points.push_back(util::pointToPoint32(util::toMsg(s.point + ref_pt)));
+    }
+    output_hl->points.push_back(
+      util::pointToPoint32(util::toMsg(headland_path.back().atEnd() + ref_pt)));
+
+    headland_swaths_pub_->publish(std::move(output_hl));
   }
 }
 

--- a/opennav_coverage/src/visualizer.cpp
+++ b/opennav_coverage/src/visualizer.cpp
@@ -30,13 +30,14 @@ void Visualizer::deactivate()
   planning_field_pub_.reset();
   swaths_pub_.reset();
   headland_swaths_pub_.reset();
+  swath_cells_pub_.reset();
 }
 
 void Visualizer::visualize(
   const Field & total_field, const Field & no_headland_field,
   const Point & ref_pt, const nav_msgs::msg::Path & nav_path,
   const Swaths swaths, const std_msgs::msg::Header & header,
-  const Path & headland_path)
+  const Path & headland_path, const F2CCells & swath_cells)
 {
   // F2C strips out reference point of all data, so we need to readd it
   // so that our visualizations mirror the true transformed output
@@ -105,26 +106,62 @@ void Visualizer::visualize(
     swaths_pub_->publish(std::move(output_swaths));
   }
 
-  // Visualize the headland perimeter loop, if driven, in a distinct color so
-  // it's not confused with the (identically-shaped) planning_field boundary.
-  if (headland_swaths_pub_->get_subscription_count() > 0 && headland_path.size() > 0) {
+  // Headland perimeter loop, if driven; DELETEALL when this goal has no pass so a
+  // previous goal's marker doesn't linger.
+  if (headland_swaths_pub_->get_subscription_count() > 0) {
     auto output_hl = std::make_unique<visualization_msgs::msg::Marker>();
     output_hl->header.stamp = header.stamp;
     output_hl->header.frame_id = GLOBAL_FRAME;
-    output_hl->action = visualization_msgs::msg::Marker::ADD;
-    output_hl->type = visualization_msgs::msg::Marker::LINE_STRIP;
-    output_hl->pose.orientation.w = 1.0;
-    output_hl->scale.x = 0.4;
-    output_hl->color.r = 1.0;
-    output_hl->color.a = 1.0;
 
-    for (const auto & s : headland_path) {
-      output_hl->points.push_back(util::pointToPoint32(util::toMsg(s.point + ref_pt)));
+    if (headland_path.size() == 0) {
+      output_hl->action = visualization_msgs::msg::Marker::DELETEALL;
+    } else {
+      output_hl->action = visualization_msgs::msg::Marker::ADD;
+      output_hl->type = visualization_msgs::msg::Marker::LINE_STRIP;
+      output_hl->pose.orientation.w = 1.0;
+      output_hl->scale.x = 0.4;
+      output_hl->color.r = 1.0;
+      output_hl->color.a = 1.0;
+
+      for (const auto & s : headland_path) {
+        output_hl->points.push_back(util::pointToPoint32(util::toMsg(s.point + ref_pt)));
+      }
+      output_hl->points.push_back(
+        util::pointToPoint32(util::toMsg(headland_path.back().atEnd() + ref_pt)));
     }
-    output_hl->points.push_back(
-      util::pointToPoint32(util::toMsg(headland_path.back().atEnd() + ref_pt)));
 
     headland_swaths_pub_->publish(std::move(output_hl));
+  }
+
+  // Debug: draw the exact polygons swaths are generated from (post carving)
+  if (swath_cells_pub_->get_subscription_count() > 0) {
+    auto output_cells = std::make_unique<visualization_msgs::msg::Marker>();
+    output_cells->header.stamp = header.stamp;
+    output_cells->header.frame_id = GLOBAL_FRAME;
+
+    if (swath_cells.size() == 0) {
+      output_cells->action = visualization_msgs::msg::Marker::DELETEALL;
+    } else {
+      output_cells->action = visualization_msgs::msg::Marker::ADD;
+      output_cells->type = visualization_msgs::msg::Marker::LINE_LIST;
+      output_cells->pose.orientation.w = 1.0;
+      output_cells->scale.x = 0.2;
+      output_cells->color.g = 1.0;
+      output_cells->color.b = 1.0;
+      output_cells->color.a = 1.0;
+
+      for (size_t i = 0; i < swath_cells.size(); ++i) {
+        const Polygon border = swath_cells.getCellBorder(i);
+        for (size_t j = 0; j + 1 < border.size(); ++j) {
+          output_cells->points.push_back(
+            util::pointToPoint32(util::toMsg(border.getGeometry(j) + ref_pt)));
+          output_cells->points.push_back(
+            util::pointToPoint32(util::toMsg(border.getGeometry(j + 1) + ref_pt)));
+        }
+      }
+    }
+
+    swath_cells_pub_->publish(std::move(output_cells));
   }
 }
 

--- a/opennav_coverage/test/test_headland.cpp
+++ b/opennav_coverage/test/test_headland.cpp
@@ -138,6 +138,44 @@ TEST(HeadlandTests, TestheadlandMultiCellCollapseSkipped)
   EXPECT_GT(result.getGeometry(0).area(), 0.0);
 }
 
+TEST(HeadlandTests, TestheadlandBetweenCells)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto generator = HeadlandShim(node);
+
+  // Two 50x100 cells sharing the x=50 border, inside a 100x100 outer boundary.
+  F2CCell left(F2CLinearRing({
+      F2CPoint(0, 0), F2CPoint(50, 0), F2CPoint(50, 100), F2CPoint(0, 100), F2CPoint(0, 0)}));
+  F2CCell right(F2CLinearRing({
+      F2CPoint(50, 0), F2CPoint(100, 0), F2CPoint(100, 100),
+      F2CPoint(50, 100), F2CPoint(50, 0)}));
+  F2CCells cells;
+  cells.addGeometry(left);
+  cells.addGeometry(right);
+
+  F2CCells result = generator.generateHeadlandsBetweenCells(cells, 2.0);
+
+  EXPECT_EQ(result.size(), 2u);
+  // Only x=50 is carved (~48x100 each): total > full-border-buffer case (8832)
+  // but < the original (10000).
+  EXPECT_GT(result.area(), 9000.0);
+  EXPECT_LT(result.area(), 9999.0);
+
+  // Width larger than the cells collapses everything -> throws.
+  EXPECT_THROW(generator.generateHeadlandsBetweenCells(cells, 60.0), CoverageException);
+
+  // Cells facing each other across a void share no border, so nothing may be
+  // carved (route headland only ever goes between truly adjacent cells).
+  F2CCell far_right(F2CLinearRing({
+      F2CPoint(60, 0), F2CPoint(110, 0), F2CPoint(110, 100),
+      F2CPoint(60, 100), F2CPoint(60, 0)}));
+  F2CCells apart;
+  apart.addGeometry(left);
+  apart.addGeometry(far_right);
+  F2CCells untouched = generator.generateHeadlandsBetweenCells(apart, 2.0);
+  EXPECT_NEAR(untouched.area(), apart.area(), 1e-3);
+}
+
 TEST(HeadlandTests, TestheadlandSwathRings)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");

--- a/opennav_coverage/test/test_headland.cpp
+++ b/opennav_coverage/test/test_headland.cpp
@@ -138,6 +138,31 @@ TEST(HeadlandTests, TestheadlandMultiCellCollapseSkipped)
   EXPECT_GT(result.getGeometry(0).area(), 0.0);
 }
 
+TEST(HeadlandTests, TestheadlandSwathRings)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto generator = HeadlandShim(node);
+
+  F2CCell cell(F2CLinearRing({
+      F2CPoint(0, 0), F2CPoint(100, 0), F2CPoint(100, 100),
+      F2CPoint(0, 100), F2CPoint(0, 0)}));
+
+  opennav_coverage_msgs::msg::HeadlandMode settings;  // default width 2.0 m
+  // 2.0 / 0.7 -> 3 concentric passes, ordered outer to inner
+  auto rings = generator.generateHeadlandSwaths(cell, 0.7, settings);
+
+  EXPECT_EQ(rings.size(), 3u);
+  double prev_area = cell.area();
+  for (const auto & ring : rings) {
+    ASSERT_GT(ring.size(), 0u);
+    EXPECT_LT(ring.getGeometry(0).area(), prev_area);
+    prev_area = ring.getGeometry(0).area();
+  }
+
+  // Invalid operation width must throw rather than divide by zero
+  EXPECT_THROW(generator.generateHeadlandSwaths(cell, 0.0, settings), CoverageException);
+}
+
 TEST(HeadlandTests, TestheadlandMultiCellAllCollapseThrows)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");

--- a/opennav_coverage/test/test_server.cpp
+++ b/opennav_coverage/test/test_server.cpp
@@ -41,14 +41,31 @@ public:
   ServerShim()
   : CoverageServer()
   {}
+  ~ServerShim()
+  {
+    // Deactivate blocks until the worker thread finishes, so members aren't destroyed under it.
+    if (activated_) {
+      rclcpp_lifecycle::State state;
+      this->on_deactivate(state);
+      this->on_cleanup(state);
+    }
+  }
   void configure(const rclcpp_lifecycle::State & state)
   {
     this->on_configure(state);
     cartesian_frame_ = false;  // Test files in GPS
   }
   void setCartesianFrame(bool v) {cartesian_frame_ = v;}
-  void activate(const rclcpp_lifecycle::State & state) {this->on_activate(state);}
-  void deactivate(const rclcpp_lifecycle::State & state) {this->on_deactivate(state);}
+  void activate(const rclcpp_lifecycle::State & state)
+  {
+    this->on_activate(state);
+    activated_ = true;
+  }
+  void deactivate(const rclcpp_lifecycle::State & state)
+  {
+    this->on_deactivate(state);
+    activated_ = false;
+  }
   void cleanup(const rclcpp_lifecycle::State & state) {this->on_cleanup(state);}
   void shutdown(const rclcpp_lifecycle::State & state) {this->on_shutdown(state);}
 
@@ -56,6 +73,9 @@ public:
   {
     return validateGoal(req);
   }
+
+private:
+  bool activated_{false};
 };
 
 TEST(ServerTest, LifecycleTest)

--- a/opennav_coverage/test/test_utils.cpp
+++ b/opennav_coverage/test/test_utils.cpp
@@ -538,8 +538,8 @@ TEST(UtilsTests, TesttoNavPathMsgHLSwathVelocity)
 
   EXPECT_EQ(nav_path.poses.size(), vels.size());
   EXPECT_EQ(nav_path.poses.size(), dirs.size());
-  // HL_SWATH state: velocity=1.5, direction=FORWARD, passes through as one point
-  // (discretizeSwath does not densify HL_SWATH, only SWATH)
+  // HL_SWATH state: velocity=1.5, direction=FORWARD. Now densified like SWATH
+  // (discretizeSwathLike splits HL_SWATH too), so every sub-point keeps vel/dir.
   EXPECT_NEAR(vels[0], 1.5, 1e-6);
   EXPECT_FALSE(dirs[0]);
   // TURN state: velocity=0.5, direction=BACKWARD
@@ -578,6 +578,53 @@ TEST(UtilsTests, TesttoNavPathMsgDensifyVelocitySizeMatch)
   // SWATH poses are forward; TURN poses are backward
   EXPECT_FALSE(dirs[0]);
   EXPECT_TRUE(dirs.back());
+}
+
+// HL_SWATH must be densified, not passed through as a single waypoint.
+TEST(UtilsTests, TesttoNavPathMsgHLSwathDensified)
+{
+  std_msgs::msg::Header header_in;
+  header_in.frame_id = "test";
+  Path path_in;
+
+  PathState hl_swath;
+  hl_swath.type = f2c::types::PathSectionType::HL_SWATH;
+  hl_swath.point = Point(0.0, 0.0);
+  hl_swath.len = 1.0;
+  hl_swath.angle = 0.0;
+  hl_swath.velocity = 1.0;
+  hl_swath.dir = f2c::types::PathDirection::FORWARD;
+  path_in.addState(hl_swath);
+
+  F2CField field;
+  auto nav_path = util::toNavPathMsg(path_in, field, header_in, true, 0.1f);
+
+  // len 1.0 at 0.1 spacing -> ~10 sub-points
+  EXPECT_GT(nav_path.poses.size(), 5u);
+}
+
+// Headland perimeter loop is built from a field boundary as HL_SWATH states,
+// starting at the boundary vertex closest to the given anchor.
+TEST(UtilsTests, TesttoHeadlandPerimeterPath)
+{
+  F2CLinearRing ring;
+  ring.addPoint(0.0, 0.0);
+  ring.addPoint(10.0, 0.0);
+  ring.addPoint(10.0, 10.0);
+  ring.addPoint(0.0, 10.0);
+  ring.addPoint(0.0, 0.0);
+  Field area(ring);
+
+  // Anchor closest to (10, 10) -> loop should start there.
+  Path path = util::toHeadlandPerimeterPath(area, 1.0, Point(9.0, 9.0));
+
+  EXPECT_EQ(path.size(), 4u);
+  for (const auto & s : path.getStates()) {
+    EXPECT_EQ(s.type, f2c::types::PathSectionType::HL_SWATH);
+    EXPECT_NEAR(s.velocity, 1.0, 1e-6);
+  }
+  EXPECT_NEAR(path[0].point.getX(), 10.0, 1e-6);
+  EXPECT_NEAR(path[0].point.getY(), 10.0, 1e-6);
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage_demo/params/rviz_config.rviz
+++ b/opennav_coverage_demo/params/rviz_config.rviz
@@ -616,6 +616,32 @@ Visualization Manager:
         Reliability Policy: Reliable
         Value: /coverage_server/swaths
       Value: true
+    - Class: rviz_default_plugins/Marker
+      Enabled: true
+      Name: HeadlandSwaths
+      Namespaces:
+        "": true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /coverage_server/headland_swaths
+      Value: true
+    - Class: rviz_default_plugins/Marker
+      Enabled: true
+      Name: SwathCells
+      Namespaces:
+        "": true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /coverage_server/swath_cells
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/opennav_coverage_demo/params/rviz_config.rviz
+++ b/opennav_coverage_demo/params/rviz_config.rviz
@@ -630,7 +630,7 @@ Visualization Manager:
         Value: /coverage_server/headland_swaths
       Value: true
     - Class: rviz_default_plugins/Marker
-      Enabled: true
+      Enabled: false
       Name: SwathCells
       Namespaces:
         "": true
@@ -641,7 +641,7 @@ Visualization Manager:
         History Policy: Keep Last
         Reliability Policy: Reliable
         Value: /coverage_server/swath_cells
-      Value: true
+      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -27,6 +27,14 @@ opennav_coverage_msgs/PathMode path_mode
 bool use_start_pose False
 opennav_coverage_msgs/Coordinate start_pose
 
+# Optional: also cover the headland ring area ("drive the headland").
+bool generate_headland_swaths False
+# True: drive the headland before the inner coverage; False: after it
+bool headland_first False
+# False: a single perimeter pass. True: concentric passes spaced by the
+# operation width to fully sweep the headland band (count = width / operation_width)
+bool headland_full_coverage False
+
 ---
 #result definition
 

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -7,6 +7,9 @@ bool generate_headland True
 bool generate_route True
 bool generate_path True
 
+# Decomposition only: corridor width on cells' shared borders. 0 = operation width.
+float32 route_headland_width 0.0
+
 # The field specification to use.
 # If using polygons, bounding polygon must be first, followed by inner cutouts
 # Both must specify if the data is cartesian or GPS coordinates


### PR DESCRIPTION
## Summary

Route corridors between adjacent cells and optional headland driving for
**decomposed** fields. Every change is opt-in or behavior-preserving by default,
so a request that doesn't decompose the field (or leaves the new fields unset)
plans exactly as before.

1. Route corridors only between adjacent cells (`route_headland_width`)
2. Optional headland driving (`generate_headland_swaths`)
3. Non-TSP + decomposition rejected early; dynamic turn params

## 1. Route corridors between adjacent cells

`route_headland_width` (default `0.0` = operation width) carves a travel
corridor **only** on borders shared by two adjacent decomposed cells. Edges that
already have a headland are left untouched — a corridor is only ever added
between two cells, never on the field boundary.

## 2. Optional headland driving

Adds goal fields to optionally cover the headland ring ("drive the headland"):

```
bool generate_headland_swaths False
bool headland_first          False   # drive headland before inner coverage (else after)
bool headland_full_coverage  False   # concentric band sweep (else a single perimeter pass)
```

All default false, so headland coverage is off unless requested.
`default_generate_headland_swaths` is also exposed as a parameter.

## 3. Rejections and dynamic params

- Non-TSP route modes (BOUSTROPHEDON/SNAKE/SPIRAL/CUSTOM) don't have a
  cross-cell ordering, so combining them with decomposition is rejected early
  with a clear error instead of producing a bad route.
- `min_turning_radius`, `linear_curv_change`, and
  `default_generate_headland_swaths` are now dynamic parameters.

## Also included

- The `headland_swaths` RViz marker now publishes `DELETEALL` when a goal drives
  no headland pass, so a previous goal's loop doesn't linger.
- test_server teardown now waits for the action worker to finish (fixes a
  heap-corruption/segfault in the tests).
