### PR TITLE
Route decomposed fields along headlands (Lyrical)

### DIFF
--- a/opennav_coverage/include/opennav_coverage/headland_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/headland_generator.hpp
@@ -87,6 +87,16 @@ public:
 
 protected:
   /**
+   * @brief Resolves the generator and width to use for a request, falling back
+   *        to the configured defaults when the request leaves the mode UNKNOWN.
+   * @param settings Action request information
+   * @param width Output: the headland width to apply
+   * @return Generator to use (never null; throws CoverageException otherwise)
+   */
+  HeadlandGeneratorPtr resolveGenerator(
+    const opennav_coverage_msgs::msg::HeadlandMode & settings, double & width);
+
+  /**
    * @brief Creates generator pointer of a requested type
    * @param type Headland generator type to create
    * @return Generator to use

--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -47,6 +47,14 @@ public:
       node, "default_route_type", rclcpp::ParameterValue("BOUSTROPHEDON"));
     std::string type_str = node->get_parameter("default_route_type").as_string();
     default_type_ = toType(type_str);
+
+    // Global-genRoute vs per-cell-fallback threshold: raise for better routes on larger
+    // fields, lower if F2C v2.0.0's genRoute runs out of memory.
+    nav2::declare_parameter_if_not_declared(
+      node, "default_max_swaths_for_global_route", rclcpp::ParameterValue(300));
+    default_max_swaths_for_global_route_ =
+      node->get_parameter("default_max_swaths_for_global_route").as_int();
+
     default_generator_ = createGenerator(default_type_);
 
     nav2::declare_parameter_if_not_declared(
@@ -123,6 +131,7 @@ public:
   void setTspTimeLimit(const int v) {default_tsp_time_limit_ = v;}
   void setTspSearchForOptimum(const bool v) {default_tsp_search_for_optimum_ = v;}
   void setTspDTol(const double v) {default_tsp_d_tol_ = v;}
+  void setMaxSwathsForGlobalRoute(const int v) {default_max_swaths_for_global_route_ = v;}
 
 protected:
   /**
@@ -154,6 +163,7 @@ protected:
   int default_tsp_time_limit_{1};
   bool default_tsp_search_for_optimum_{false};
   double default_tsp_d_tol_{1e-4};
+  int default_max_swaths_for_global_route_{300};
   rclcpp::Logger logger_{rclcpp::get_logger("RouteGenerator")};
 };
 

--- a/opennav_coverage/include/opennav_coverage/route_method.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_method.hpp
@@ -84,8 +84,8 @@ private:
 class TspRouteMethod : public RouteMethod
 {
 public:
-  explicit TspRouteMethod(const rclcpp::Logger & logger)
-  : logger_(logger) {}
+  TspRouteMethod(const rclcpp::Logger & logger, size_t max_swaths_for_global_route)
+  : logger_(logger), max_swaths_for_global_route_(max_swaths_for_global_route) {}
 
   F2CRoute plan(
     const F2CCells & cells,
@@ -94,6 +94,7 @@ public:
 
 private:
   rclcpp::Logger logger_;
+  size_t max_swaths_for_global_route_;
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -192,29 +192,40 @@ void CoverageServer::computeCoveragePath()
       "Generating coverage path in %s frame for zone with %zu outer nodes and %zu inner polygons.",
       frame_id.c_str(), field.getGeometry(0).size(), field.size() - 1);
 
-    // (1) Optional: decompose non-convex field, then remove headland, then generate swaths
+    // (1) Build the cells to cover: remove the headland, optionally decomposing first
     const bool do_decomp = goal->generate_decomp || default_generate_decomp_;
 
     Field field_no_headland = field;
-    F2CCells cells;
+    // route_cells: travel graph for the route planner. swath_cells: cells swaths
+    // are generated from. Differ only when decomposing with a headland.
+    F2CCells route_cells;
+    F2CCells swath_cells;
     if (do_decomp) {
-      F2CCells raw_cells;
-      raw_cells.addGeometry(field);
-      F2CCells decomposed = decomp_gen_->decompose(raw_cells, goal->decomp_mode);
-
-      // Apply a separate headland to each sub-cell
-      cells = goal->generate_headland ?
-        headland_gen_->generateHeadlands(decomposed, goal->headland_mode) : decomposed;
+      // Headland-first: remove the headland from the whole field, decompose that into
+      // border-sharing cells (the travel graph), then remove the headland again per
+      // cell for the swaths, so connections run along the shared headland.
+      Field travel_ring = field;
+      if (goal->generate_headland) {
+        travel_ring = headland_gen_->generateHeadlands(field, goal->headland_mode);
+        field_no_headland = travel_ring;
+      }
+      F2CCells travel_ring_cells;
+      travel_ring_cells.addGeometry(travel_ring);
+      route_cells = decomp_gen_->decompose(travel_ring_cells, goal->decomp_mode);
+      swath_cells = goal->generate_headland ?
+        headland_gen_->generateHeadlands(route_cells, goal->headland_mode) : route_cells;
     } else {
-      // (1) Optional: Remove headland from polygon field
+      // No decomposition: remove the headland from the single field cell
       if (goal->generate_headland) {
         field_no_headland = headland_gen_->generateHeadlands(field, goal->headland_mode);
       }
-      cells.addGeometry(field_no_headland);
+      route_cells.addGeometry(field_no_headland);
+      swath_cells = route_cells;
     }
 
     // (2) Generate swaths to cover polygon field, including internal voids
-    F2CSwathsByCells swaths_by_cells = swath_gen_->generateSwathsByCells(cells, goal->swath_mode);
+    F2CSwathsByCells swaths_by_cells =
+      swath_gen_->generateSwathsByCells(swath_cells, goal->swath_mode);
     Swaths swaths = swaths_by_cells.flatten();
 
     // (3) Optional: Generate an ordered route through the unordered swaths
@@ -223,7 +234,7 @@ void CoverageServer::computeCoveragePath()
     header.frame_id = frame_id;
     Path path;
     if (goal->generate_route) {
-      F2CRoute route = route_gen_->generateRoute(cells, swaths_by_cells, goal->route_mode);
+      F2CRoute route = route_gen_->generateRoute(route_cells, swaths_by_cells, goal->route_mode);
       if (route.isEmpty()) {
         throw CoverageException("Route planner returned an empty route.");
       }

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -339,6 +339,8 @@ CoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramet
         route_gen_->setSpiralN(parameter.as_int());
       } else if (name == "default_tsp_time_limit") {
         route_gen_->setTspTimeLimit(parameter.as_int());
+      } else if (name == "default_max_swaths_for_global_route") {
+        route_gen_->setMaxSwathsForGlobalRoute(parameter.as_int());
       }
     } else if (type == ParameterType::PARAMETER_INTEGER_ARRAY) {
       if (name == "default_custom_order") {

--- a/opennav_coverage/src/headland_generator.cpp
+++ b/opennav_coverage/src/headland_generator.cpp
@@ -20,12 +20,11 @@
 namespace opennav_coverage
 {
 
-Field HeadlandGenerator::generateHeadlands(
-  const Field & field, const opennav_coverage_msgs::msg::HeadlandMode & settings)
+HeadlandGeneratorPtr HeadlandGenerator::resolveGenerator(
+  const opennav_coverage_msgs::msg::HeadlandMode & settings, double & width)
 {
   HeadlandType action_type = toType(settings.mode);
   HeadlandGeneratorPtr generator{nullptr};
-  double width = 0.0;
 
   // If not set by action, use default mode
   if (action_type == HeadlandType::UNKNOWN) {
@@ -37,21 +36,46 @@ Field HeadlandGenerator::generateHeadlands(
     width = settings.width;
   }
 
-
   if (!generator) {
     throw CoverageException("No valid headlands mode set! Options: CONSTANT.");
   }
 
-  RCLCPP_DEBUG(logger_, "Generating Headland with generator: %s", toString(action_type).c_str());
+  RCLCPP_DEBUG(
+    logger_, "Generating Headland with generator: %s", toString(action_type).c_str());
+  return generator;
+}
+
+Field HeadlandGenerator::generateHeadlands(
+  const Field & field, const opennav_coverage_msgs::msg::HeadlandMode & settings)
+{
+  double width = 0.0;
+  HeadlandGeneratorPtr generator = resolveGenerator(settings, width);
   return generator->generateHeadlands(Fields(field), width).getGeometry(0);
 }
 
 F2CCells HeadlandGenerator::generateHeadlands(
   const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings)
 {
+  double width = 0.0;
+  HeadlandGeneratorPtr generator = resolveGenerator(settings, width);
+
+  // Apply the headland to each sub-cell independently: decomposed cells share
+  // borders, so buffering the whole F2CCells at once would only shrink the outer
+  // boundary and drop the inter-cell headlands.
   F2CCells result;
   for (size_t i = 0; i < cells.size(); ++i) {
-    result.addGeometry(generateHeadlands(cells.getGeometry(i), settings));
+    // Skip sub-cells that the inward buffer collapses to empty; keep every polygon
+    // a buffer may split one cell into.
+    F2CCells cell_headland = generator->generateHeadlands(Fields(cells.getGeometry(i)), width);
+    for (size_t j = 0; j < cell_headland.size(); ++j) {
+      result.addGeometry(cell_headland.getGeometry(j));
+    }
+  }
+
+  if (result.size() == 0) {
+    throw CoverageException(
+      "Headland width is too large for the decomposed field: every sub-cell "
+      "collapsed. Reduce the headland width or disable decomposition.");
   }
   return result;
 }

--- a/opennav_coverage/src/route_generator.cpp
+++ b/opennav_coverage/src/route_generator.cpp
@@ -75,7 +75,8 @@ RouteGeneratorPtr RouteGenerator::createGenerator(const RouteType & type)
       return std::make_shared<SwathOrderMethod>(
         type, std::make_shared<f2c::rp::CustomOrder>());
     case RouteType::TSP:
-      return std::make_shared<TspRouteMethod>(logger_);
+      return std::make_shared<TspRouteMethod>(
+        logger_, static_cast<size_t>(default_max_swaths_for_global_route_));
     default:
       RCLCPP_WARN(logger_, "Unknown route type set!");
       return RouteGeneratorPtr{nullptr};

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -19,11 +19,23 @@
 namespace opennav_coverage
 {
 
+// Above this many total swaths, TspRouteMethod falls back to per-cell TSP to avoid
+// F2C's O(N^2) all-pairs path matrix that OOMs on large decompositions.
+static constexpr size_t kMaxSwathsForGlobalRoute = 300;
+
 F2CRoute SwathOrderMethod::plan(
-  const F2CCells & /*cells*/,
+  const F2CCells & cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings)
 {
+  // The orderers assume a single cell; multi-cell (decomposed) input breaks their
+  // ordering, so only TSP handles it. Reject rather than produce a bad route.
+  if (cells.size() > 1) {
+    throw CoverageException(
+            "Non-TSP route modes are not supported with field decomposition; "
+            "use route_mode TSP or disable decomposition.");
+  }
+
   // The F2C orderers operate on a single flat swath list.
   if (type_ == RouteType::SPIRAL) {
     dynamic_cast<f2c::rp::SpiralOrder *>(orderer_.get())->setSpiralSize(settings.spiral_n);
@@ -56,10 +68,22 @@ F2CRoute TspRouteMethod::plan(
     redirect_swaths ? "true" : "false", time_limit,
     search_for_optimum ? "true" : "false", d_tol);
 
-  // Per-cell TSP instead of one multi-cell genRoute call: F2C v2.0.0's
-  // RoutePlannerBase builds the full all-pairs path matrix, which exhausts
-  // memory (bad_alloc) on decomposed input. The cells are disconnected anyway,
-  // so solve each one alone and stitch the routes with straight-line bridges.
+  // One global genRoute keeps inter-cell connections along the shared borders/
+  // headland. Capped by swath count: F2C's all-pairs path matrix grows with the
+  // square of swath count and can run out of memory on large decompositions.
+  size_t total_swaths = 0;
+  for (size_t i = 0; i < swaths_by_cells.size(); ++i) {
+    total_swaths += swaths_by_cells.at(i).size();
+  }
+  if (total_swaths <= kMaxSwathsForGlobalRoute) {
+    f2c::rp::RoutePlannerBase rp;
+    return rp.genRoute(
+      cells, swaths_by_cells,
+      /*show_log=*/false, d_tol, redirect_swaths, time_limit, search_for_optimum);
+  }
+
+  // Fallback for large decompositions: solve each cell alone and stitch the
+  // routes together with a straight-line bridge between cells.
   F2CRoute merged;
   for (size_t i = 0; i < cells.size(); ++i) {
     if (i >= swaths_by_cells.size() || swaths_by_cells.at(i).size() == 0) {

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -19,10 +19,6 @@
 namespace opennav_coverage
 {
 
-// Above this many total swaths, TspRouteMethod falls back to per-cell TSP to avoid
-// F2C's O(N^2) all-pairs path matrix that OOMs on large decompositions.
-static constexpr size_t kMaxSwathsForGlobalRoute = 300;
-
 F2CRoute SwathOrderMethod::plan(
   const F2CCells & cells,
   const F2CSwathsByCells & swaths_by_cells,
@@ -75,11 +71,10 @@ F2CRoute TspRouteMethod::plan(
   for (size_t i = 0; i < swaths_by_cells.size(); ++i) {
     total_swaths += swaths_by_cells.at(i).size();
   }
-  if (total_swaths <= kMaxSwathsForGlobalRoute) {
+  if (total_swaths <= max_swaths_for_global_route_) {
     f2c::rp::RoutePlannerBase rp;
     return rp.genRoute(
-      cells, swaths_by_cells,
-      /*show_log=*/false, d_tol, redirect_swaths, time_limit, search_for_optimum);
+      cells, swaths_by_cells, false, d_tol, redirect_swaths, time_limit, search_for_optimum);
   }
 
   // Fallback for large decompositions: solve each cell alone and stitch the
@@ -95,12 +90,7 @@ F2CRoute TspRouteMethod::plan(
 
     f2c::rp::RoutePlannerBase rp;
     F2CRoute cell_route = rp.genRoute(
-      cell, cell_swaths,
-      /*show_log=*/false,
-      d_tol,
-      redirect_swaths,
-      time_limit,
-      search_for_optimum);
+      cell, cell_swaths, false, d_tol, redirect_swaths, time_limit, search_for_optimum);
     if (cell_route.isEmpty()) {
       continue;
     }

--- a/opennav_coverage/test/test_headland.cpp
+++ b/opennav_coverage/test/test_headland.cpp
@@ -113,4 +113,48 @@ TEST(HeadlandTests, TestheadlandGenerationMultiCell)
   EXPECT_LT(result.getGeometry(1).area(), area_in);
 }
 
+TEST(HeadlandTests, TestheadlandMultiCellCollapseSkipped)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto generator = HeadlandShim(node);
+
+  // Big cell (100x100) survives the default 2 m inward buffer; the 3 m-wide strip
+  // collapses to an empty geometry. The collapsed cell must be skipped rather than
+  // dereferenced (which would throw "Geometry does not contain point 0").
+  F2CCell big(F2CLinearRing({
+      F2CPoint(0, 0), F2CPoint(100, 0), F2CPoint(100, 100),
+      F2CPoint(0, 100), F2CPoint(0, 0)}));
+  F2CCell thin(F2CLinearRing({
+      F2CPoint(200, 0), F2CPoint(203, 0), F2CPoint(203, 100),
+      F2CPoint(200, 100), F2CPoint(200, 0)}));
+  F2CCells cells;
+  cells.addGeometry(big);
+  cells.addGeometry(thin);
+
+  opennav_coverage_msgs::msg::HeadlandMode settings;  // default width 2.0 m
+  F2CCells result = generator.generateHeadlands(cells, settings);
+
+  EXPECT_EQ(result.size(), 1u);
+  EXPECT_GT(result.getGeometry(0).area(), 0.0);
+}
+
+TEST(HeadlandTests, TestheadlandMultiCellAllCollapseThrows)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto generator = HeadlandShim(node);
+
+  // Every sub-cell is a 3 m-wide strip that collapses under the 2 m buffer, so the
+  // result is empty and a CoverageException is thrown instead of returning nothing.
+  F2CCell thin_a(F2CLinearRing({
+      F2CPoint(0, 0), F2CPoint(3, 0), F2CPoint(3, 100), F2CPoint(0, 100), F2CPoint(0, 0)}));
+  F2CCell thin_b(F2CLinearRing({
+      F2CPoint(50, 0), F2CPoint(53, 0), F2CPoint(53, 100), F2CPoint(50, 100), F2CPoint(50, 0)}));
+  F2CCells cells;
+  cells.addGeometry(thin_a);
+  cells.addGeometry(thin_b);
+
+  opennav_coverage_msgs::msg::HeadlandMode settings;  // default width 2.0 m
+  EXPECT_THROW(generator.generateHeadlands(cells, settings), CoverageException);
+}
+
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_server.cpp
+++ b/opennav_coverage/test/test_server.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <filesystem>
 
 #include "gtest/gtest.h"
@@ -146,8 +147,9 @@ TEST(ServerTest, testDecompPath)
   goal_msg.generate_decomp = true;
   goal_msg.decomp_mode.mode = "TRAPEZOIDAL";
   goal_msg.generate_headland = true;
-  goal_msg.generate_route = true;
-  goal_msg.generate_path = true;
+  // Covers decompose + headland + swath only; route/path is covered elsewhere.
+  goal_msg.generate_route = false;
+  goal_msg.generate_path = false;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   const std::filesystem::path share_dir =
@@ -170,9 +172,58 @@ TEST(ServerTest, testDecompPath)
   EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
 }
 
+TEST(ServerTest, testDecompNonTSPRouteRejected)
+{
+  // Non-TSP route modes only handle a single cell, so combining one with
+  // decomposition (multi-cell) must be rejected with INVALID_MODE_SET.
+  auto node = std::make_shared<ServerShim>();
+  rclcpp_lifecycle::State state;
+  node->configure(state);
+  node->activate(state);
+  auto node_thread = std::make_unique<nav2::NodeThread>(node);
+
+  auto client_node = std::make_shared<rclcpp::Node>("my_node_decomp_nontsp");
+  auto action_client =
+    rclcpp_action::create_client<opennav_coverage_msgs::action::ComputeCoveragePath>(
+    client_node, "compute_coverage_path");
+  action_client->wait_for_action_server();
+
+  auto goal_msg = opennav_coverage_msgs::action::ComputeCoveragePath::Goal();
+  goal_msg.use_gml_file = true;
+  goal_msg.generate_decomp = true;
+  goal_msg.decomp_mode.mode = "TRAPEZOIDAL";
+  goal_msg.generate_headland = true;
+  goal_msg.generate_route = true;
+  goal_msg.route_mode.mode = "BOUSTROPHEDON";  // non-TSP -> rejected with decomposition
+  goal_msg.generate_path = true;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::filesystem::path share_dir =
+    ament_index_cpp::get_package_share_directory("opennav_coverage");
+#pragma GCC diagnostic pop
+  goal_msg.gml_field = (share_dir / "test_field.xml").string();
+
+  auto future_goal_handle = action_client->async_send_goal(goal_msg);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_goal_handle),
+    rclcpp::FutureReturnCode::SUCCESS);
+  auto goal_handle = future_goal_handle.get();
+
+  auto future_result = action_client->async_get_result(goal_handle);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_result),
+    rclcpp::FutureReturnCode::SUCCESS);
+
+  auto result = future_result.get();
+  EXPECT_EQ(result.code, rclcpp_action::ResultCode::ABORTED);
+  EXPECT_EQ(
+    result.result->error_code,
+    opennav_coverage_msgs::action::ComputeCoveragePath::Result::INVALID_MODE_SET);
+}
+
 TEST(ServerTest, testDecompPathNoHeadland)
 {
-  // generate_headland=false exercises the cells_no_headland = decomposed branch
+  // generate_headland=false exercises the decompose-without-headland swath branch
   auto node = std::make_shared<ServerShim>();
   rclcpp_lifecycle::State state;
   node->configure(state);
@@ -261,9 +312,8 @@ TEST(ServerTest, testTSPRouteNoPath)
 
 TEST(ServerTest, testTSPDecompHeadlandPath)
 {
-  // Exercises the TSP branch end-to-end with decomp+headland enabled together:
-  // trapezoidal decomposition yields ~11 disconnected (headland-shrunk) cells,
-  // which RouteGenerator solves as per-cell TSP stitched in sweep order.
+  // TSP + decompose + headland end-to-end. test_field.xml has enough swaths to
+  // exceed the global-genRoute cap, so this exercises the per-cell TSP fallback.
   auto node = std::make_shared<ServerShim>();
   rclcpp_lifecycle::State state;
   node->configure(state);
@@ -284,7 +334,7 @@ TEST(ServerTest, testTSPDecompHeadlandPath)
   goal_msg.generate_route = true;
   goal_msg.generate_path = true;
   goal_msg.route_mode.mode = "TSP";
-  // Per-cell OR-Tools limit; keeps the 11-cell total bounded in CI.
+  // Keep the per-cell OR-Tools search short so CI stays fast.
   goal_msg.route_mode.tsp_time_limit = 1;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
@@ -307,6 +357,60 @@ TEST(ServerTest, testTSPDecompHeadlandPath)
   auto result = future_result.get();
   EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
   EXPECT_FALSE(result.result->nav_path.poses.empty());
+  // Sanity-check the computed path: swaths, connection turns, and task time.
+  EXPECT_FALSE(result.result->coverage_path.swaths.empty());
+  EXPECT_TRUE(result.result->coverage_path.contains_turns);
+  EXPECT_TRUE(std::isfinite(result.result->task_time));
+}
+
+TEST(ServerTest, testTSPNoDecompPath)
+{
+  // TSP on a single (non-decomposed) field: the common case, single genRoute call.
+  auto node = std::make_shared<ServerShim>();
+  rclcpp_lifecycle::State state;
+  node->configure(state);
+  node->activate(state);
+  auto node_thread = std::make_unique<nav2::NodeThread>(node);
+
+  auto client_node = std::make_shared<rclcpp::Node>("my_node_tsp_nodecomp");
+  auto action_client =
+    rclcpp_action::create_client<opennav_coverage_msgs::action::ComputeCoveragePath>(
+    client_node, "compute_coverage_path");
+  action_client->wait_for_action_server();
+
+  auto goal_msg = opennav_coverage_msgs::action::ComputeCoveragePath::Goal();
+  goal_msg.use_gml_file = true;
+  goal_msg.generate_decomp = false;
+  goal_msg.generate_headland = true;
+  goal_msg.generate_route = true;
+  goal_msg.route_mode.mode = "TSP";
+  goal_msg.route_mode.tsp_time_limit = 1;
+  goal_msg.generate_path = true;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  const std::filesystem::path share_dir =
+    ament_index_cpp::get_package_share_directory("opennav_coverage");
+#pragma GCC diagnostic pop
+  goal_msg.gml_field = (share_dir / "test_field.xml").string();
+
+  auto future_goal_handle = action_client->async_send_goal(goal_msg);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_goal_handle),
+    rclcpp::FutureReturnCode::SUCCESS);
+  auto goal_handle = future_goal_handle.get();
+
+  auto future_result = action_client->async_get_result(goal_handle);
+  EXPECT_EQ(
+    rclcpp::spin_until_future_complete(client_node, future_result),
+    rclcpp::FutureReturnCode::SUCCESS);
+
+  auto result = future_result.get();
+  EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
+  EXPECT_FALSE(result.result->nav_path.poses.empty());
+  // Sanity-check the computed path: swaths, connection turns, and task time.
+  EXPECT_FALSE(result.result->coverage_path.swaths.empty());
+  EXPECT_TRUE(result.result->coverage_path.contains_turns);
+  EXPECT_TRUE(std::isfinite(result.result->task_time));
 }
 
 TEST(ServerTest, testDynamicParams)


### PR DESCRIPTION
## Summary

Ports #119 to the `lyrical` branch. Completes decomposition-with-route support:
routes decomposed (multi-cell) fields along their headlands so inter-cell
connections follow the shared headland, and fixes a multi-cell headland crash.
Builds on the lyrical ports of #112/#113/#117 (PRs #123, #126, #130).

## Changes

**Route decomposed fields along headlands**
- Previously a decomposed field applied the headland per sub-cell first, leaving
  each cell a disconnected island; per-cell TSP then stitched routes with
  straight-line bridges that cut across the field. Non-TSP modes flattened the
  multi-cell swaths into a single-cell orderer, fanning connections across the field.
- Now: shrink the whole field to a travel ring, decompose it, then shrink each
  sub-cell again for the swath area. `genRoute` is fed the border-sharing travel
  cells so inter-cell connections follow the headlands.
- `generateRouteTSP` takes separate `travel_cells` and `swath_cells`: small fields
  use a single global `genRoute`; large fields (swath count above a cap) fall back
  to per-cell TSP to avoid the O(N²) all-pairs OOM.
- Non-TSP route modes combined with decomposition are rejected with a clear
  `INVALID_MODE_SET` error.
- Decomposed cells and swaths are reused across the swath and TSP branches.

**Make the global-route swath cap a parameter**
- `default_max_swaths_for_global_route` (default 300) replaces the hard-coded
  threshold, tunable at runtime via the dynamic-parameters callback.

**Fix multi-cell headland crash on collapsed sub-cells**
- The multi-cell `generateHeadlands(F2CCells)` overload applied the headland to
  each sub-cell through the single-`Field` overload (ending in `.getGeometry(0)`).
  `ConstHL` is a negative buffer, so a sub-cell narrower than ~2×width collapses to
  empty and `getGeometry(0)` threw "Geometry does not contain point 0" on
  decomposed fields.
- Buffer each sub-cell directly, skip cells that collapse to empty, add every
  resulting polygon (a negative buffer may split one cell into several), and throw
  a clear `CoverageException` if every sub-cell collapses. Generator/width
  resolution extracted into a shared `resolveGenerator()` helper.

## Distro notes (lyrical)

No adaptation from #119 was needed — every touched file is byte-identical to the
rolling base, so the #119 delta applies verbatim. `lyrical` already uses the
`nav2::` (`nav2_ros_common`) convention (`declare_parameter_if_not_declared`,
`NodeThread`) and `test_server.cpp` already includes `<cmath>` and `<filesystem>`.
