### PR TITLE
Route decomposed fields with per-cell TSP and entry-angle-aware stitching

### DIFF
--- a/opennav_coverage/include/opennav_coverage/path_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/path_generator.hpp
@@ -118,6 +118,28 @@ public:
 
 protected:
   /**
+   * @brief Assemble the full path: swath groups via F2C planPath, connections
+   *        via appendConnection (see there for why connections aren't just
+   *        handed to F2C's own route-level planPath).
+   * @param route Route with ordered swath groups and connections
+   * @param curve Curve generator for turns
+   * @return Full path
+   */
+  Path assemblePath(const F2CRoute & route, f2c::pp::TurningBase & curve);
+
+  /**
+   * @brief Append one connection between swath groups to the path
+   * @param path Path to append to
+   * @param prev Previous swath group (may be empty at the route start)
+   * @param connection Connection waypoints from the route (may be empty)
+   * @param next Next swath group (may be empty at the route end)
+   * @param curve Curve generator used when there is no polyline to follow
+   */
+  void appendConnection(
+    Path & path, const Swaths & prev, const F2CMultiPoint & connection,
+    const Swaths & next, f2c::pp::TurningBase & curve);
+
+  /**
    * @brief Creates generator pointer of a requested type
    * @param type curve generator type to create
    * @return Generator to use

--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -110,6 +110,21 @@ public:
     const std::optional<F2CPoint> & start_end_point = std::nullopt);
 
   /**
+   * @brief Whether the request (or the default it falls back to) is TSP.
+   *        Used to reject non-TSP + decomposition before any geometry work.
+   * @param settings Action request information
+   * @return true when the route mode resolves to TSP
+   */
+  bool resolvesToTsp(const opennav_coverage_msgs::msg::RouteMode & settings)
+  {
+    RouteType type = toType(settings.mode);
+    if (type == RouteType::UNKNOWN) {
+      type = default_type_;
+    }
+    return type == RouteType::TSP;
+  }
+
+  /**
    * @brief Sets the mode manually of the Route for dynamic parameters
    * @param mode String for mode to use
    */

--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -97,17 +97,31 @@ public:
 
   /**
    * @brief Generate an ordered route for any mode (orderers or TSP).
-   * @param cells Travel cells whose borders route connections may follow
+   * @param travel_cells Border-sharing cells inter-cell bridges may follow
+   * @param swath_cells Cells the swaths were generated from (carved corridors)
    * @param swaths_by_cells Per-cell swaths from generateSwathsByCells
    * @param settings Action request information
    * @param start_end_point Optional start/end point for the route (TSP mode only)
    * @return F2CRoute (ordered swath groups plus any connections)
    */
   F2CRoute generateRoute(
-    const F2CCells & cells,
+    const F2CCells & travel_cells,
+    const F2CCells & swath_cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
     const std::optional<F2CPoint> & start_end_point = std::nullopt);
+
+  /**
+   * @brief Convenience overload when the travel and swath cells are the same
+   */
+  F2CRoute generateRoute(
+    const F2CCells & cells,
+    const F2CSwathsByCells & swaths_by_cells,
+    const opennav_coverage_msgs::msg::RouteMode & settings,
+    const std::optional<F2CPoint> & start_end = std::nullopt)
+  {
+    return generateRoute(cells, cells, swaths_by_cells, settings, start_end);
+  }
 
   /**
    * @brief Whether the request (or the default it falls back to) is TSP.

--- a/opennav_coverage/include/opennav_coverage/route_method.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_method.hpp
@@ -41,14 +41,16 @@ public:
 
   /**
    * @brief Plan an ordered route over the swaths.
-   * @param cells Travel cells whose borders the route connections may follow
-   * @param swaths_by_cells Per-cell swaths to be covered
+   * @param travel_cells Border-sharing cells the inter-cell bridges may follow
+   * @param swath_cells Cells the swaths were generated from (carved corridors)
+   * @param swaths_by_cells Per-cell swaths, indexed like swath_cells
    * @param settings Fully-resolved RouteMode (server has already applied defaults)
    * @param start_end_point Optional start/end point for the route (used by TSP only)
    * @return Ordered route: swath groups plus any headland connections
    */
   virtual F2CRoute plan(
-    const F2CCells & cells,
+    const F2CCells & travel_cells,
+    const F2CCells & swath_cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
     const std::optional<F2CPoint> & start_end_point = std::nullopt) = 0;
@@ -69,7 +71,8 @@ public:
   : type_(type), orderer_(std::move(orderer)) {}
 
   F2CRoute plan(
-    const F2CCells & cells,
+    const F2CCells & travel_cells,
+    const F2CCells & swath_cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
     const std::optional<F2CPoint> & start_end_point = std::nullopt) override;
@@ -81,18 +84,20 @@ private:
 
 /**
  * @class TspRouteMethod
- * @brief Adapts F2C's `RoutePlannerBase` (OR-Tools TSP). Solves each cell
- *        separately and stitches the per-cell routes in sweep order, avoiding the
- *        all-pairs path matrix that exhausts memory on decomposed multi-cell input.
+ * @brief Adapts F2C's `RoutePlannerBase` (OR-Tools TSP). Single-cell input is one
+ *        genRoute call. Multi-cell input is solved per cell and stitched in
+ *        nearest-neighbor order (see route_method.cpp), keeping cells contiguous.
  */
 class TspRouteMethod : public RouteMethod
 {
 public:
+  // max_swaths_for_global_route: unused, kept for ABI/call-site stability
   TspRouteMethod(const rclcpp::Logger & logger, size_t max_swaths_for_global_route)
   : logger_(logger), max_swaths_for_global_route_(max_swaths_for_global_route) {}
 
   F2CRoute plan(
-    const F2CCells & cells,
+    const F2CCells & travel_cells,
+    const F2CCells & swath_cells,
     const F2CSwathsByCells & swaths_by_cells,
     const opennav_coverage_msgs::msg::RouteMode & settings,
     const std::optional<F2CPoint> & start_end_point = std::nullopt) override;

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -196,6 +196,13 @@ void CoverageServer::computeCoveragePath()
     // (1) Build the cells to cover: remove the headland, optionally decomposing first
     const bool do_decomp = goal->generate_decomp || default_generate_decomp_;
 
+    // Reject non-TSP+decomp up front; the deep check only fires after all the geometry work.
+    if (do_decomp && goal->generate_route && !route_gen_->resolvesToTsp(goal->route_mode)) {
+      throw CoverageException(
+              "Non-TSP route modes are not supported with field decomposition; "
+              "use route_mode TSP or disable decomposition.");
+    }
+
     Field field_no_headland = field;
     // route_cells: travel graph for the route planner. swath_cells: cells swaths
     // are generated from. Differ only when decomposing with a headland.

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -242,13 +242,14 @@ void CoverageServer::computeCoveragePath()
     header.frame_id = frame_id;
     Path path;
     if (goal->generate_route) {
-      std::optional<F2CPoint> start_end_point;
+      std::optional<F2CPoint> start_end;
       if (goal->use_start_pose) {
-        start_end_point = util::toFieldFrame(
+        start_end = util::toFieldFrame(
           F2CPoint(goal->start_pose.axis1, goal->start_pose.axis2), master_field, cartesian_frame_);
       }
-      F2CRoute route =
-        route_gen_->generateRoute(route_cells, swaths_by_cells, goal->route_mode, start_end_point);
+      // Per-cell routes pair with swath_cells; bridges travel route_cells to detour voids.
+      F2CRoute route = route_gen_->generateRoute(
+        route_cells, swath_cells, swaths_by_cells, goal->route_mode, start_end);
       if (route.isEmpty()) {
         throw CoverageException("Route planner returned an empty route.");
       }

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cmath>
 #include <vector>
 #include <string>
 
@@ -47,13 +48,91 @@ Path PathGenerator::generatePath(
     logger_,
     "Generating path with curve: %s", toString(action_type, action_continuity_type).c_str());
   curve->setDiscretization(turn_point_distance);
-  Path path = generator_->planPath(robot_params_->getRobot(), route, *curve);
+  Path path = assemblePath(route, *curve);
 
   // Optionally thin out near-duplicate points (e.g. in turns)
   if (reduce_path_) {
     path.reduce(reduce_min_dist_);
   }
   return path;
+}
+
+Path PathGenerator::assemblePath(const F2CRoute & route, f2c::pp::TurningBase & curve)
+{
+  auto & robot = robot_params_->getRobot();
+  Path path;
+  for (size_t i = 0; i < route.sizeVectorSwaths(); ++i) {
+    const Swaths prev = (i > 0) ? route.getSwaths(i - 1) : Swaths();
+    const F2CMultiPoint connection =
+      (i < route.sizeConnections()) ? route.getConnection(i) : F2CMultiPoint();
+    appendConnection(path, prev, connection, route.getSwaths(i), curve);
+    path += generator_->planPath(robot, route.getSwaths(i), curve);
+  }
+  if (route.sizeConnections() > route.sizeVectorSwaths()) {
+    appendConnection(
+      path, route.getLastSwaths(), route.getLastConnection(), Swaths(), curve);
+  }
+  return path;
+}
+
+void PathGenerator::appendConnection(
+  Path & path, const Swaths & prev, const F2CMultiPoint & connection,
+  const Swaths & next, f2c::pp::TurningBase & curve)
+{
+  auto & robot = robot_params_->getRobot();
+  const bool has_prev = prev.size() > 0;
+  const bool has_next = next.size() > 0;
+  if (!has_prev && !has_next && connection.size() < 2) {
+    return;
+  }
+
+  std::vector<Point> pts;
+  if (has_prev) {
+    pts.push_back(prev.back().endPoint());
+  }
+  for (size_t i = 0; i < connection.size(); ++i) {
+    pts.push_back(connection[i]);
+  }
+  if (has_next) {
+    pts.push_back(next[0].startPoint());
+  }
+  if (pts.size() < 2) {
+    return;
+  }
+
+  double polyline_len = 0.0;
+  for (size_t i = 0; i + 1 < pts.size(); ++i) {
+    polyline_len += pts[i].distance(pts[i + 1]);
+  }
+  const double direct_len = pts.front().distance(pts.back());
+
+  // Near-straight hop between two swath groups: one curve (the u-turn). Boundary
+  // connections (to/from a TSP start point) fall through to keep that point.
+  if (has_prev && has_next && polyline_len < 1.3 * std::max(direct_len, 1e-6)) {
+    path += curve.createTurn(
+      robot, prev.back().endPoint(), prev.back().getOutAngle(),
+      next[0].startPoint(), next[0].getInAngle());
+    return;
+  }
+
+  // The polyline detours (e.g. around a concave notch): follow it verbatim as
+  // HL_SWATH states so the vehicle stays on the planned border/corridor track.
+  for (size_t i = 0; i + 1 < pts.size(); ++i) {
+    const double dx = pts[i + 1].getX() - pts[i].getX();
+    const double dy = pts[i + 1].getY() - pts[i].getY();
+    const double len = std::hypot(dx, dy);
+    if (len < 1e-6) {
+      continue;
+    }
+    PathState s;
+    s.point = pts[i];
+    s.angle = std::atan2(dy, dx);
+    s.len = len;
+    s.dir = f2c::types::PathDirection::FORWARD;
+    s.type = f2c::types::PathSectionType::HL_SWATH;
+    s.velocity = robot.getCruiseVel();
+    path.addState(s);
+  }
 }
 
 void PathGenerator::setPathMode(const std::string & new_mode)

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -100,6 +100,24 @@ void PathGenerator::appendConnection(
     return;
   }
 
+  // Drop attachment spikes: a bridge point past the endpoint that doubles back.
+  bool changed = true;
+  while (changed && pts.size() > 2) {
+    changed = false;
+    for (const size_t i : {size_t{1}, pts.size() - 2}) {
+      const Point & a = pts[i - 1];
+      const Point & b = pts[i];
+      const Point & c = pts[i + 1];
+      const double dot = (b.getX() - a.getX()) * (c.getX() - b.getX()) +
+        (b.getY() - a.getY()) * (c.getY() - b.getY());
+      if (dot < 0.0 && a.distance(b) < a.distance(c)) {
+        pts.erase(pts.begin() + i);
+        changed = true;
+        break;
+      }
+    }
+  }
+
   double polyline_len = 0.0;
   for (size_t i = 0; i + 1 < pts.size(); ++i) {
     polyline_len += pts[i].distance(pts[i + 1]);

--- a/opennav_coverage/src/route_generator.cpp
+++ b/opennav_coverage/src/route_generator.cpp
@@ -22,9 +22,10 @@ namespace opennav_coverage
 {
 
 F2CRoute RouteGenerator::generateRoute(
-  const F2CCells & cells, const F2CSwathsByCells & swaths_by_cells,
+  const F2CCells & travel_cells, const F2CCells & swath_cells,
+  const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end_point)
+  const std::optional<F2CPoint> & start_end)
 {
   RouteType action_type = toType(settings.mode);
 
@@ -50,12 +51,12 @@ F2CRoute RouteGenerator::generateRoute(
             "No valid route mode set! Options: BOUSTROPHEDON, SNAKE, SPIRAL, CUSTOM, TSP.");
   }
 
-  if (start_end_point && action_type != RouteType::TSP) {
+  if (start_end && action_type != RouteType::TSP) {
     RCLCPP_WARN(logger_, "start_pose ignored: only used in TSP route mode.");
   }
 
   RCLCPP_DEBUG(logger_, "Generating route: %s", toString(action_type).c_str());
-  return method->plan(cells, swaths_by_cells, eff, start_end_point);
+  return method->plan(travel_cells, swath_cells, swaths_by_cells, eff, start_end);
 }
 
 void RouteGenerator::setMode(const std::string & new_mode)

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <limits>
+#include <utility>
 #include <vector>
 
 #include "opennav_coverage/route_method.hpp"
@@ -141,25 +144,35 @@ F2CRoute TspRouteMethod::plan(
     return F2CRoute();
   }
 
-  // Visit cells in nearest-neighbor order, entering each from whichever end of
-  // its route is closer (reversing the cell route when needed), so the bridges
-  // between cells stay short instead of jumping across the field.
+  // Nearest-neighbor cell order; entry cost also penalizes heading mismatch to avoid S-maneuvers.
+  const auto angDiff = [](double a, double b) {
+      return std::fabs(std::atan2(std::sin(a - b), std::cos(a - b)));
+    };
   const auto pickNearest =
-    [&cell_routes, &remaining](const F2CPoint & from, bool & reversed) {
+    [&cell_routes, &remaining, &angDiff](
+    const F2CPoint & from, const std::optional<double> & from_angle, bool & reversed) {
       size_t best_idx = remaining[0];
-      double best_dist = std::numeric_limits<double>::max();
+      double best_cost = std::numeric_limits<double>::max();
       for (const size_t idx : remaining) {
-        const double d_fwd = from.distance(cell_routes[idx].startPoint());
-        const double d_rev = from.distance(cell_routes[idx].endPoint());
-        if (d_fwd < best_dist) {
-          best_dist = d_fwd;
-          best_idx = idx;
-          reversed = false;
-        }
-        if (d_rev < best_dist) {
-          best_dist = d_rev;
-          best_idx = idx;
-          reversed = true;
+        const auto & groups = cell_routes[idx].getVectorSwaths();
+        const F2CSwath & first_swath = groups.front().at(0);
+        const F2CSwath & last_swath = groups.back().back();
+        const std::array<std::pair<F2CPoint, double>, 2> entries = {
+          std::make_pair(cell_routes[idx].startPoint(), first_swath.getInAngle()),
+          std::make_pair(cell_routes[idx].endPoint(), last_swath.getOutAngle() + M_PI)};
+        for (size_t e = 0; e < entries.size(); ++e) {
+          const double dist = from.distance(entries[e].first);
+          double cost = dist;
+          if (from_angle && dist > 1e-6) {
+            const double bearing = (entries[e].first - from).getAngleFromPoint();
+            cost += first_swath.getWidth() *
+              (angDiff(*from_angle, bearing) + angDiff(bearing, entries[e].second));
+          }
+          if (cost < best_cost) {
+            best_cost = cost;
+            best_idx = idx;
+            reversed = (e == 1);
+          }
         }
       }
       return best_idx;
@@ -172,7 +185,7 @@ F2CRoute TspRouteMethod::plan(
       logger_,
       "Multi-cell route: start_pose picks the nearest cell; the route starts at "
       "that cell's own start, not at the exact point.");
-    current = pickNearest(*start_end, current_reversed);
+    current = pickNearest(*start_end, std::nullopt, current_reversed);
   }
 
   // Bridges follow the travel-cell pair's border graph, not a line that could cut a void.
@@ -245,7 +258,10 @@ F2CRoute TspRouteMethod::plan(
     if (remaining.empty()) {
       break;
     }
-    current = pickNearest(merged.endPoint(), current_reversed);
+    current = pickNearest(
+      merged.endPoint(),
+      last_swath ? std::optional<double>(last_swath->getOutAngle()) : std::nullopt,
+      current_reversed);
   }
   return merged;
 }

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -60,15 +60,13 @@ F2CRoute reversedRoute(const F2CRoute & route)
 }  // namespace
 
 F2CRoute SwathOrderMethod::plan(
-  const F2CCells & travel_cells,
+  const F2CCells & /*travel_cells*/,
   const F2CCells & swath_cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end)
+  // start_end is a TSP-only concept; the generator already warns the user, so it is ignored here
+  const std::optional<F2CPoint> & /*start_end*/)
 {
-  (void)travel_cells;
-  (void)start_end;  // TSP-only concept; the generator already warns the user
-
   // These orderers assume a single cell; multi-cell input breaks their ordering.
   if (swath_cells.size() > 1) {
     throw CoverageException(

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <limits>
 #include <vector>
 
 #include "opennav_coverage/route_method.hpp"
@@ -19,21 +21,58 @@
 namespace opennav_coverage
 {
 
+namespace
+{
+
+F2CMultiPoint reversedConnection(const F2CMultiPoint & mp)
+{
+  std::vector<F2CPoint> pts;
+  pts.reserve(mp.size());
+  for (int i = static_cast<int>(mp.size()) - 1; i >= 0; --i) {
+    pts.emplace_back(mp[i]);
+  }
+  return F2CMultiPoint(pts);
+}
+
+// Reverses group order, each swath, and each connection so a cell can be entered from either end.
+F2CRoute reversedRoute(const F2CRoute & route)
+{
+  const auto & groups = route.getVectorSwaths();
+  const auto & conns = route.getConnections();
+  F2CRoute out;
+  for (int k = static_cast<int>(groups.size()) - 1; k >= 0; --k) {
+    F2CSwaths swaths = groups[k];
+    swaths.reverse();
+    for (size_t s = 0; s < swaths.size(); ++s) {
+      swaths.at(s).reverse();
+    }
+    const size_t conn_after = static_cast<size_t>(k) + 1;
+    out.addConnectedSwaths(
+      conn_after < conns.size() ? reversedConnection(conns[conn_after]) : F2CMultiPoint(),
+      swaths);
+  }
+  return out;
+}
+
+}  // namespace
+
 F2CRoute SwathOrderMethod::plan(
-  const F2CCells & cells,
+  const F2CCells & travel_cells,
+  const F2CCells & swath_cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & /*start_end_point*/)
+  const std::optional<F2CPoint> & start_end)
 {
-  // The orderers assume a single cell; multi-cell (decomposed) input breaks their
-  // ordering, so only TSP handles it. Reject rather than produce a bad route.
-  if (cells.size() > 1) {
+  (void)travel_cells;
+  (void)start_end;  // TSP-only concept; the generator already warns the user
+
+  // These orderers assume a single cell; multi-cell input breaks their ordering.
+  if (swath_cells.size() > 1) {
     throw CoverageException(
             "Non-TSP route modes are not supported with field decomposition; "
             "use route_mode TSP or disable decomposition.");
   }
 
-  // The F2C orderers operate on a single flat swath list.
   if (type_ == RouteType::SPIRAL) {
     dynamic_cast<f2c::rp::SpiralOrder *>(orderer_.get())->setSpiralSize(settings.spiral_n);
   } else if (type_ == RouteType::CUSTOM) {
@@ -50,10 +89,11 @@ F2CRoute SwathOrderMethod::plan(
 }
 
 F2CRoute TspRouteMethod::plan(
-  const F2CCells & cells,
+  const F2CCells & travel_cells,
+  const F2CCells & swath_cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  const std::optional<F2CPoint> & start_end_point)
+  const std::optional<F2CPoint> & start_end)
 {
   const bool redirect_swaths = settings.tsp_redirect_swaths;
   const long int time_limit = settings.tsp_time_limit;  // NOLINT
@@ -66,51 +106,133 @@ F2CRoute TspRouteMethod::plan(
     redirect_swaths ? "true" : "false", time_limit,
     search_for_optimum ? "true" : "false", d_tol);
 
-  // One global genRoute keeps inter-cell connections along the shared borders/
-  // headland. Capped by swath count: F2C's all-pairs path matrix grows with the
-  // square of swath count and can run out of memory on large decompositions.
-  size_t total_swaths = 0;
-  for (size_t i = 0; i < swaths_by_cells.size(); ++i) {
-    total_swaths += swaths_by_cells.at(i).size();
-  }
-  if (total_swaths <= max_swaths_for_global_route_) {
+  // Single cell: one genRoute call, which honors the start/end point exactly.
+  if (swath_cells.size() <= 1) {
     f2c::rp::RoutePlannerBase rp;
-    if (start_end_point) {
-      rp.setStartAndEndPoint(*start_end_point);
+    if (start_end) {
+      rp.setStartAndEndPoint(*start_end);
     }
     return rp.genRoute(
-      cells, swaths_by_cells, false, d_tol, redirect_swaths, time_limit, search_for_optimum);
+      swath_cells, swaths_by_cells, false, d_tol, redirect_swaths, time_limit,
+      search_for_optimum);
   }
 
-  // start_end_point can't be honored per-cell, so warn and drop it in the stitched fallback
-  if (start_end_point) {
-    RCLCPP_WARN(
-      logger_,
-      "start_pose ignored: swath count exceeds max_swaths_for_global_route; route is stitched "
-      "per-cell.");
-  }
-
-  // Fallback for large decompositions: solve each cell alone and stitch the
-  // routes together with a straight-line bridge between cells.
-  F2CRoute merged;
-  for (size_t i = 0; i < cells.size(); ++i) {
-    if (i >= swaths_by_cells.size() || swaths_by_cells.at(i).size() == 0) {
+  // Multi-cell: solve each cell alone to avoid interleaving and the all-pairs path matrix.
+  std::vector<F2CRoute> cell_routes(swath_cells.size());
+  for (size_t i = 0; i < swath_cells.size() && i < swaths_by_cells.size(); ++i) {
+    if (swaths_by_cells.at(i).size() == 0) {
       continue;
     }
-    F2CCells cell(cells.getGeometry(i));
+    F2CCells cell(swath_cells.getGeometry(i));
     F2CSwathsByCells cell_swaths;
     cell_swaths.emplace_back(swaths_by_cells.at(i));
-
     f2c::rp::RoutePlannerBase rp;
-    F2CRoute cell_route = rp.genRoute(
+    cell_routes[i] = rp.genRoute(
       cell, cell_swaths, false, d_tol, redirect_swaths, time_limit, search_for_optimum);
-    if (cell_route.isEmpty()) {
-      continue;
-    }
+  }
 
-    if (!merged.isEmpty()) {
+  std::vector<size_t> remaining;
+  for (size_t i = 0; i < cell_routes.size(); ++i) {
+    if (!cell_routes[i].isEmpty()) {
+      remaining.push_back(i);
+    }
+  }
+  if (remaining.empty()) {
+    return F2CRoute();
+  }
+
+  // Visit cells in nearest-neighbor order, entering each from whichever end of
+  // its route is closer (reversing the cell route when needed), so the bridges
+  // between cells stay short instead of jumping across the field.
+  const auto pickNearest =
+    [&cell_routes, &remaining](const F2CPoint & from, bool & reversed) {
+      size_t best_idx = remaining[0];
+      double best_dist = std::numeric_limits<double>::max();
+      for (const size_t idx : remaining) {
+        const double d_fwd = from.distance(cell_routes[idx].startPoint());
+        const double d_rev = from.distance(cell_routes[idx].endPoint());
+        if (d_fwd < best_dist) {
+          best_dist = d_fwd;
+          best_idx = idx;
+          reversed = false;
+        }
+        if (d_rev < best_dist) {
+          best_dist = d_rev;
+          best_idx = idx;
+          reversed = true;
+        }
+      }
+      return best_idx;
+    };
+
+  size_t current = remaining[0];
+  bool current_reversed = false;
+  if (start_end) {
+    RCLCPP_WARN(
+      logger_,
+      "Multi-cell route: start_pose picks the nearest cell; the route starts at "
+      "that cell's own start, not at the exact point.");
+    current = pickNearest(*start_end, current_reversed);
+  }
+
+  // Bridges follow the travel-cell pair's border graph, not a line that could cut a void.
+  const auto buildBridge =
+    [&travel_cells, d_tol](
+    const F2CSwath & from_swath, const F2CSwath & to_swath,
+    const F2CPoint & from, const F2CPoint & to) {
+      F2CSwaths end_swaths;
+      end_swaths.emplace_back(from_swath);
+      end_swaths.emplace_back(to_swath);
+      F2CSwathsByCells bridge_swaths;
+      bridge_swaths.emplace_back(end_swaths);
+
+      const auto viaGraph =
+        [&bridge_swaths, d_tol, &from, &to](const F2CCells & graph_cells) {
+          std::vector<F2CPoint> pts;
+          try {
+            f2c::rp::RoutePlannerBase rp;
+            F2CGraph2D graph = rp.createShortestGraph(graph_cells, bridge_swaths, d_tol);
+            pts = graph.shortestPath(from, to);
+          } catch (const std::exception &) {
+            pts.clear();
+          }
+          return pts;
+        };
+
+      F2CCells pair_cells;
+      const Field cell_a = travel_cells.getCellWherePoint(from);
+      if (cell_a.size() > 0) {
+        pair_cells.addGeometry(cell_a);
+      }
+      const Field cell_b = travel_cells.getCellWherePoint(to);
+      if (cell_b.size() > 0) {
+        pair_cells.addGeometry(cell_b);
+      }
+
+      std::vector<F2CPoint> bridge;
+      if (pair_cells.size() > 0) {
+        bridge = viaGraph(pair_cells);
+      }
+      if (bridge.size() < 2) {
+        bridge = viaGraph(travel_cells);
+      }
+      if (bridge.size() < 2) {
+        bridge = {from, to};
+      }
+      return bridge;
+    };
+
+  F2CRoute merged;
+  std::optional<F2CSwath> last_swath;
+  while (true) {
+    remaining.erase(std::find(remaining.begin(), remaining.end(), current));
+    const F2CRoute cell_route =
+      current_reversed ? reversedRoute(cell_routes[current]) : cell_routes[current];
+    if (!merged.isEmpty() && last_swath) {
       merged.addConnection(
-        std::vector<F2CPoint>{merged.endPoint(), cell_route.startPoint()});
+        buildBridge(
+          *last_swath, cell_route.getVectorSwaths().front().at(0),
+          merged.endPoint(), cell_route.startPoint()));
     }
     const auto & vec_swaths = cell_route.getVectorSwaths();
     const auto & connections = cell_route.getConnections();
@@ -118,6 +240,12 @@ F2CRoute TspRouteMethod::plan(
       merged.addConnectedSwaths(
         k < connections.size() ? connections[k] : F2CMultiPoint(), vec_swaths[k]);
     }
+    last_swath = cell_route.getVectorSwaths().back().back();
+
+    if (remaining.empty()) {
+      break;
+    }
+    current = pickNearest(merged.endPoint(), current_reversed);
   }
   return merged;
 }

--- a/opennav_coverage/test/test_path.cpp
+++ b/opennav_coverage/test/test_path.cpp
@@ -161,4 +161,38 @@ TEST(PathTests, TestpathGenerationFromF2CRoute)
   EXPECT_TRUE(std::isfinite(path.getTaskTime()));
 }
 
+TEST(PathTests, TestpathGenerationMultiCellConnections)
+{
+  // A multi-cell TSP route carries inter-cell connections; assemblePath must
+  // stitch them without dropping swaths or the connection track.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteGenerator route_gen(node);
+  PathShim generator(node, &robot_params);
+
+  F2CCells cells;
+  cells.addGeometry(F2CCell(F2CLinearRing({
+      F2CPoint(0, 0), F2CPoint(100, 0), F2CPoint(100, 100),
+      F2CPoint(0, 100), F2CPoint(0, 0)})));
+  cells.addGeometry(F2CCell(F2CLinearRing({
+      F2CPoint(100, 0), F2CPoint(200, 0), F2CPoint(200, 100),
+      F2CPoint(100, 100), F2CPoint(100, 0)})));
+
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode rt_settings;
+  rt_settings.mode = "TSP";
+  rt_settings.tsp_time_limit = 1;
+  F2CRoute route = route_gen.generateRoute(cells, sbc, rt_settings);
+  ASSERT_FALSE(route.isEmpty());
+  ASSERT_GE(route.sizeConnections(), 1u);
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  EXPECT_GT(path.size(), 0u);
+  EXPECT_TRUE(std::isfinite(path.getTaskTime()));
+}
+
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_route.cpp
+++ b/opennav_coverage/test/test_route.cpp
@@ -71,6 +71,19 @@ static F2CCells makeSquareCells(double s)
   return cells;
 }
 
+// Two s x s cells sharing the x=s edge, to exercise the multi-cell TSP stitch.
+static F2CCells makeTwoAdjacentCells(double s)
+{
+  F2CCells cells;
+  cells.addGeometry(F2CCell(F2CLinearRing({
+      F2CPoint(0.0, 0.0), F2CPoint(s, 0.0), F2CPoint(s, s),
+      F2CPoint(0.0, s), F2CPoint(0.0, 0.0)})));
+  cells.addGeometry(F2CCell(F2CLinearRing({
+      F2CPoint(s, 0.0), F2CPoint(2 * s, 0.0), F2CPoint(2 * s, s),
+      F2CPoint(s, s), F2CPoint(s, 0.0)})));
+  return cells;
+}
+
 TEST(RouteTests, TestrouteUtils)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");
@@ -296,22 +309,52 @@ TEST(RouteTests, TestNonTSPStartPointIgnored)
   EXPECT_NEAR(without.length(), with.length(), 1e-6);
 }
 
-TEST(RouteTests, TestTSPStitchIgnoresStartPoint)
+TEST(RouteTests, TestTSPMultiCellStitch)
 {
-  // The stitched fallback drops the start point but still produces a valid route
+  // Two cells route per-cell and stitch: every cell stays contiguous, swaths are
+  // preserved, and at least one inter-cell connection (bridge) is produced.
   auto node = std::make_shared<rclcpp::Node>("test_node");
   RobotParams robot_params(node);
   SwathGenerator swath_gen(node, &robot_params);
   RouteShim generator(node);
 
-  F2CCells cells = makeSquareCells(100.0);
+  F2CCells cells = makeTwoAdjacentCells(100.0);
   opennav_coverage_msgs::msg::SwathMode sw_settings;
   F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
-
-  generator.setMaxSwathsForGlobalRoute(0);  // force the stitched fallback
+  ASSERT_GE(sbc.size(), 2u);  // one swath group per cell
 
   opennav_coverage_msgs::msg::RouteMode settings;
   settings.mode = "TSP";
+  settings.tsp_time_limit = 1;
+  F2CRoute route = generator.generateRoute(cells, sbc, settings);
+
+  EXPECT_FALSE(route.isEmpty());
+  EXPECT_GE(route.sizeVectorSwaths(), 2u);
+  EXPECT_GE(route.sizeConnections(), 1u);
+
+  size_t total_out = 0;
+  for (size_t i = 0; i < route.sizeVectorSwaths(); ++i) {
+    total_out += route.getVectorSwaths()[i].size();
+  }
+  EXPECT_EQ(sbc.sizeTotal(), total_out);
+}
+
+TEST(RouteTests, TestTSPMultiCellStartPoint)
+{
+  // On the multi-cell path the exact start point isn't honored (the nearest cell
+  // is chosen and warned), but the route stays valid.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeTwoAdjacentCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "TSP";
+  settings.tsp_time_limit = 1;
   F2CRoute route = generator.generateRoute(cells, sbc, settings, F2CPoint(0.0, 0.0));
   EXPECT_FALSE(route.isEmpty());
 }

--- a/opennav_coverage/test/test_server.cpp
+++ b/opennav_coverage/test/test_server.cpp
@@ -41,14 +41,31 @@ public:
   ServerShim()
   : CoverageServer()
   {}
+  ~ServerShim()
+  {
+    // Deactivate blocks until the worker thread finishes, so members aren't destroyed under it.
+    if (activated_) {
+      rclcpp_lifecycle::State state;
+      this->on_deactivate(state);
+      this->on_cleanup(state);
+    }
+  }
   void configure(const rclcpp_lifecycle::State & state)
   {
     this->on_configure(state);
     cartesian_frame_ = false;  // Test files in GPS
   }
   void setCartesianFrame(bool v) {cartesian_frame_ = v;}
-  void activate(const rclcpp_lifecycle::State & state) {this->on_activate(state);}
-  void deactivate(const rclcpp_lifecycle::State & state) {this->on_deactivate(state);}
+  void activate(const rclcpp_lifecycle::State & state)
+  {
+    this->on_activate(state);
+    activated_ = true;
+  }
+  void deactivate(const rclcpp_lifecycle::State & state)
+  {
+    this->on_deactivate(state);
+    activated_ = false;
+  }
   void cleanup(const rclcpp_lifecycle::State & state) {this->on_cleanup(state);}
   void shutdown(const rclcpp_lifecycle::State & state) {this->on_shutdown(state);}
 
@@ -56,6 +73,9 @@ public:
   {
     return validateGoal(req);
   }
+
+private:
+  bool activated_{false};
 };
 
 TEST(ServerTest, LifecycleTest)


### PR DESCRIPTION
## Summary

Routes decomposed fields by solving TSP per sub-cell and stitching results with
optimized corridor transitions. Enables coverage planning on multi-cell fields
with correct per-cell ordering. Rejects non-TSP route modes early.

## The Problem

Decomposed fields split into multiple sub-cells that share borders. A global
route planner (F2C's genRoute) can't optimize across cells — it processes the
entire multi-cell geometry at once and produces poor orderings or OOM errors on
large fields. A per-cell approach lets each sub-cell be solved independently at
TSP scale, then stitched together with optimized corridor transitions.

## The Solution

**Per-Cell TSP with Optimized Entry/Exit Selection:**
- Each decomposed sub-cell's swaths are solved independently via TSP (avoiding
  the all-in-one F2C genRoute that OOMs on large multi-cell fields)
- Each cell **can be entered from two ends** (start or reversed-end), each with
  its own entry heading angle
- After per-cell TSP, cells are connected via nearest-neighbor selection:
  for the current cell's end point, pick the next unvisited cell AND entry end
  that minimize: `distance + swath_width * (heading_mismatch_penalty)`
  - This avoids sharp-angle S-maneuvers between cells
  - Each unvisited cell is evaluated both forward and reversed
- **Bridge paths** between cells run along the **travel-cell pair border graph**
  (not straight lines that could cut voids), so routing stays within valid regions
- Result: globally-ordered swaths across all cells with entry-angle-aware,
  border-aware transitions

**Stitch Turn Optimization:**
- **Heading-aware entry:** corridor entry point chosen to minimize heading
  mismatch (perpendicular entry preferred over sharp angles)
- **Spike filtering:** bridge polylines drop attachment points that double back
  at junctions (numerical artifacts from geometry operations)

**Path Emissions:**
- Route connections (inter-cell jumps, boundary transitions) are now emitted as
  HL_SWATH states in nav_path so visualization and debugging tools can render
  the stitch points

**Early Validation:**
- Non-TSP route modes (BOUSTROPHEDON, SPIRAL, SNAKE, CUSTOM) rejected before
  geometry work; clear error message guides user to TSP or disable decomposition

## Decomposition Connection: PR #135

Route corridors between decomposed cells ([PR #135](https://github.com/open-navigation/opennav_coverage/pull/135))
fixed the double-headland gaps. This PR builds on that foundation by routing
cells optimally with entry-angle-aware connections.

## Test Coverage

- `test_server` heap corruption fixed (action worker cleanup in teardown)
- Per-cell route ordering validated with multi-cell test scenarios
- Stitch maneuvers tested on synthetic bridge cases
