### PR TITLE
Carve route corridors only between adjacent decomposed cells (humble)

### DIFF
--- a/opennav_coverage/include/opennav_coverage/headland_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/headland_generator.hpp
@@ -74,6 +74,16 @@ public:
     const F2CCells & cells, const opennav_coverage_msgs::msg::HeadlandMode & settings);
 
   /**
+   * @brief Carve a route corridor only on the borders cells actually share,
+   *        leaving edges facing the outer boundary or a void untouched.
+   * @param cells Decomposed sub-cells (share internal borders)
+   * @param route_width Corridor width carved along each shared border
+   * @return Swath cells carved only on their internal borders
+   */
+  F2CCells generateHeadlandsBetweenCells(
+    const F2CCells & cells, double route_width);
+
+  /**
    * @brief Sets the mode manually of the Headland for dynamic parameters
    * @param mode String for mode to use
    */

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -210,9 +210,8 @@ void CoverageServer::computeCoveragePath()
     F2CCells route_cells;
     F2CCells swath_cells;
     if (do_decomp) {
-      // Headland-first: remove the headland from the whole field, decompose that into
-      // border-sharing cells (the travel graph), then remove the headland again per
-      // cell for the swaths, so connections run along the shared headland.
+      // Headland-first: remove the headland once from the whole field, then
+      // decompose that into border-sharing cells (the travel graph).
       Field travel_ring = field;
       if (goal->generate_headland) {
         travel_ring = headland_gen_->generateHeadlands(field, goal->headland_mode);
@@ -221,8 +220,14 @@ void CoverageServer::computeCoveragePath()
       F2CCells travel_ring_cells;
       travel_ring_cells.addGeometry(travel_ring);
       route_cells = decomp_gen_->decompose(travel_ring_cells, goal->decomp_mode);
-      swath_cells = goal->generate_headland ?
-        headland_gen_->generateHeadlands(route_cells, goal->headland_mode) : route_cells;
+      if (!goal->generate_headland) {
+        swath_cells = route_cells;
+      } else {
+        // Headland already removed before decomposing; only carve the inter-cell corridor here.
+        const double route_w = goal->route_headland_width > 0.0 ?
+          goal->route_headland_width : robot_params_->getOperationWidth();
+        swath_cells = headland_gen_->generateHeadlandsBetweenCells(route_cells, route_w);
+      }
     } else {
       // No decomposition: remove the headland from the single field cell
       if (goal->generate_headland) {

--- a/opennav_coverage/src/headland_generator.cpp
+++ b/opennav_coverage/src/headland_generator.cpp
@@ -80,6 +80,59 @@ F2CCells HeadlandGenerator::generateHeadlands(
   return result;
 }
 
+F2CCells HeadlandGenerator::generateHeadlandsBetweenCells(
+  const F2CCells & cells, double route_width)
+{
+  if (route_width <= 0.0) {
+    throw CoverageException("route_headland_width must be > 0 to carve inter-cell corridors.");
+  }
+
+  // kMinCellArea drops slivers left by carving: F2C's unchecked geometry casts
+  // corrupt memory on degenerate (near-zero-area) polygons.
+  const double kSharedTol = 1e-3;
+  const double kMinCellArea = 1e-3;
+
+  F2CCells result;
+  for (size_t i = 0; i < cells.size(); ++i) {
+    F2CCells swath_cell;
+    swath_cell.addGeometry(cells.getGeometry(i));
+    const Polygon ring_i = cells.getCellBorder(i);
+
+    for (size_t k = 0; k < cells.size(); ++k) {
+      if (k == i) {
+        continue;
+      }
+      const Polygon ring_k = cells.getCellBorder(k);
+      // Carve only the edges of cell_i that lie on cell_k's border: corridors
+      // exist strictly between adjacent cells, never on headland or void edges.
+      for (size_t e = 0; e + 1 < ring_i.size(); ++e) {
+        const Point a = ring_i.getGeometry(e);
+        const Point b = ring_i.getGeometry(e + 1);
+        const Point mid = (a + b) * 0.5;
+        if (ring_k.closestPointTo(a).distance(a) < kSharedTol &&
+          ring_k.closestPointTo(b).distance(b) < kSharedTol &&
+          ring_k.closestPointTo(mid).distance(mid) < kSharedTol)
+        {
+          swath_cell = swath_cell.difference(
+            Field::buffer(LineString(a, b), route_width));
+        }
+      }
+    }
+
+    for (size_t j = 0; j < swath_cell.size(); ++j) {
+      if (swath_cell.getGeometry(j).area() > kMinCellArea) {
+        result.addGeometry(swath_cell.getGeometry(j));
+      }
+    }
+  }
+
+  if (result.size() == 0) {
+    throw CoverageException(
+            "route_headland_width is too large: every sub-cell collapsed. Reduce it.");
+  }
+  return result;
+}
+
 void HeadlandGenerator::setMode(const std::string & new_mode)
 {
   default_type_ = toType(new_mode);

--- a/opennav_coverage/test/test_headland.cpp
+++ b/opennav_coverage/test/test_headland.cpp
@@ -140,6 +140,47 @@ TEST(HeadlandTests, TestheadlandMultiCellCollapseSkipped)
   EXPECT_GT(result.getGeometry(0).area(), 0.0);
 }
 
+TEST(HeadlandTests, TestheadlandBetweenCells)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  auto generator = HeadlandShim(node);
+
+  // Two 50x100 cells sharing the x=50 border, inside a 100x100 outer boundary.
+  F2CCell left(F2CLinearRing(
+    {
+      F2CPoint(0, 0), F2CPoint(50, 0), F2CPoint(50, 100), F2CPoint(0, 100), F2CPoint(0, 0)}));
+  F2CCell right(F2CLinearRing(
+    {
+      F2CPoint(50, 0), F2CPoint(100, 0), F2CPoint(100, 100),
+      F2CPoint(50, 100), F2CPoint(50, 0)}));
+  F2CCells cells;
+  cells.addGeometry(left);
+  cells.addGeometry(right);
+
+  F2CCells result = generator.generateHeadlandsBetweenCells(cells, 2.0);
+
+  EXPECT_EQ(result.size(), 2u);
+  // Only x=50 is carved (~48x100 each): total > full-border-buffer case (8832)
+  // but < the original (10000).
+  EXPECT_GT(result.area(), 9000.0);
+  EXPECT_LT(result.area(), 9999.0);
+
+  // Width larger than the cells collapses everything -> throws.
+  EXPECT_THROW(generator.generateHeadlandsBetweenCells(cells, 60.0), CoverageException);
+
+  // Cells facing each other across a void share no border, so nothing may be
+  // carved (route headland only ever goes between truly adjacent cells).
+  F2CCell far_right(F2CLinearRing(
+    {
+      F2CPoint(60, 0), F2CPoint(110, 0), F2CPoint(110, 100),
+      F2CPoint(60, 100), F2CPoint(60, 0)}));
+  F2CCells apart;
+  apart.addGeometry(left);
+  apart.addGeometry(far_right);
+  F2CCells untouched = generator.generateHeadlandsBetweenCells(apart, 2.0);
+  EXPECT_NEAR(untouched.area(), apart.area(), 1e-3);
+}
+
 TEST(HeadlandTests, TestheadlandMultiCellAllCollapseThrows)
 {
   auto node = std::make_shared<rclcpp::Node>("test_node");

--- a/opennav_coverage_msgs/action/ComputeCoveragePath.action
+++ b/opennav_coverage_msgs/action/ComputeCoveragePath.action
@@ -7,6 +7,9 @@ bool generate_headland True
 bool generate_route True
 bool generate_path True
 
+# Decomposition only: corridor width on cells' shared borders. 0 uses the operation width. Other values override.
+float32 route_headland_width 0.0
+
 # The field specification to use.
 # If using polygons, bounding polygon must be first, followed by inner cutouts
 # Both must specify if the data is cartesian or GPS coordinates


### PR DESCRIPTION
## Summary

Humble port of #135 (Rolling) / #142 (Jazzy). Fixes a double-headland gap between
decomposed cells. Behavior-preserving unless the field is decomposed with a
headland.

**The bug:** when a field is decomposed with a headland, the headland was being
applied twice. The field headland is already removed once before decomposing;
then applying `generateHeadlands` to every sub-cell insets a headland on **all**
of that cell's borders again — including the borders shared with a neighbor. Two
adjacent cells each carving a headland on the same shared edge leaves a
double-width gap between them, and outer edges get a redundant second headland
stacked on the one already removed at the field level.

**The fix:** `generateHeadlandsBetweenCells` carves a corridor **only** on the
borders two cells actually share. An edge is carved only when both its endpoints
and its midpoint lie on a neighbor cell's border, so shared borders get exactly
one corridor and edges facing the outer boundary or a void keep their single,
already-correct headland. `route_headland_width` (default `0.0` = operation
width) sets the corridor width.

```
generateHeadlands per sub-cell (before)      generateHeadlandsBetweenCells (after)
headland inset on EVERY border               corridor ONLY on the shared A│B border

 ┌─────────────┐ ┌─────────────┐              ┌─────────────┬───┬─────────────┐
 │▒▒▒▒▒▒▒▒▒▒▒▒▒│ │▒▒▒▒▒▒▒▒▒▒▒▒▒│              │             │░░░│             │
 │▒┌─────────┐▒│ │▒┌─────────┐▒│              │             │░░░│             │
 │▒│    A    │▒│ │▒│    B    │▒│              │      A      │░░░│      B      │
 │▒│         │▒│ │▒│         │▒│              │             │░░░│             │
 │▒└─────────┘▒│ │▒└─────────┘▒│              │             │░░░│             │
 │▒▒▒▒▒▒▒▒▒▒▒▒▒│ │▒▒▒▒▒▒▒▒▒▒▒▒▒│              │             │░░░│             │
 └─────────────┘ └─────────────┘              └─────────────┴───┴─────────────┘
   double headland on the shared edge           one corridor where cells meet;
   + redundant outer headland                   outer boundary left untouched
```

## Port notes

Straight port — all five touched files carry the same hunks as #135/#142, with no
functional adaptation. The only Humble-specific change is formatting: Humble's
older `ament_uncrustify` requires the brace-on-its-own-line `F2CLinearRing(\n    {`
form in the new test and a deeper continuation indent on the new `throw`, matching
the style the Humble base already uses in the surrounding code. Verified clean with
Humble's `ament_uncrustify` and `ament_cpplint`.
