### PR TITLE
Support non-TSP route modes with field decomposition

### DIFF
--- a/opennav_coverage/include/opennav_coverage/route_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_generator.hpp
@@ -124,18 +124,18 @@ public:
   }
 
   /**
-   * @brief Whether the request (or the default it falls back to) is TSP.
-   *        Used to reject non-TSP + decomposition before any geometry work.
-   * @param settings Action request information
-   * @return true when the route mode resolves to TSP
+   * @brief Whether the goal's route mode resolves to CUSTOM, the one mode whose
+   *        absolute order vector cannot be split across decomposed cells
+   * @param settings Route mode settings from the action goal
+   * @return True if the effective mode is CUSTOM
    */
-  bool resolvesToTsp(const opennav_coverage_msgs::msg::RouteMode & settings)
+  bool resolvesToCustom(const opennav_coverage_msgs::msg::RouteMode & settings)
   {
     RouteType type = toType(settings.mode);
     if (type == RouteType::UNKNOWN) {
       type = default_type_;
     }
-    return type == RouteType::TSP;
+    return type == RouteType::CUSTOM;
   }
 
   /**

--- a/opennav_coverage/include/opennav_coverage/route_method.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_method.hpp
@@ -59,16 +59,19 @@ public:
 /**
  * @class SwathOrderMethod
  * @brief Adapts the F2C swath-ordering modes (BOUSTROPHEDON, SNAKE, SPIRAL,
- *        CUSTOM). Flattens the per-cell swaths, orders them with the wrapped
- *        `SingleCellSwathsOrderBase`, and wraps the ordered swaths into a
- *        single-group `F2CRoute` (no connections) so the output type matches TSP.
+ *        CUSTOM). Single-cell input orders the flattened swaths with the wrapped
+ *        `SingleCellSwathsOrderBase`. Multi-cell input is ordered per cell and
+ *        stitched with the shared stitch layer (see route_method.cpp), the same
+ *        one `TspRouteMethod` uses. CUSTOM is rejected for multi-cell: its order
+ *        vector cannot be split across cells.
  */
 class SwathOrderMethod : public RouteMethod
 {
 public:
   SwathOrderMethod(
-    RouteType type, std::shared_ptr<f2c::rp::SingleCellSwathsOrderBase> orderer)
-  : type_(type), orderer_(std::move(orderer)) {}
+    const rclcpp::Logger & logger, RouteType type,
+    std::shared_ptr<f2c::rp::SingleCellSwathsOrderBase> orderer)
+  : logger_(logger), type_(type), orderer_(std::move(orderer)) {}
 
   F2CRoute plan(
     const F2CCells & travel_cells,
@@ -78,6 +81,7 @@ public:
     const std::optional<F2CPoint> & start_end_point = std::nullopt) override;
 
 private:
+  rclcpp::Logger logger_;
   RouteType type_;
   std::shared_ptr<f2c::rp::SingleCellSwathsOrderBase> orderer_;
 };

--- a/opennav_coverage/include/opennav_coverage/route_method.hpp
+++ b/opennav_coverage/include/opennav_coverage/route_method.hpp
@@ -59,11 +59,8 @@ public:
 /**
  * @class SwathOrderMethod
  * @brief Adapts the F2C swath-ordering modes (BOUSTROPHEDON, SNAKE, SPIRAL,
- *        CUSTOM). Single-cell input orders the flattened swaths with the wrapped
- *        `SingleCellSwathsOrderBase`. Multi-cell input is ordered per cell and
- *        stitched with the shared stitch layer (see route_method.cpp), the same
- *        one `TspRouteMethod` uses. CUSTOM is rejected for multi-cell: its order
- *        vector cannot be split across cells.
+ *        CUSTOM). Multi-cell input is ordered per cell and stitched; CUSTOM is
+ *        rejected there, as its order vector cannot be split across cells.
  */
 class SwathOrderMethod : public RouteMethod
 {

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -200,11 +200,11 @@ void CoverageServer::computeCoveragePath()
     // (1) Build the cells to cover: remove the headland, optionally decomposing first
     const bool do_decomp = goal->generate_decomp || default_generate_decomp_;
 
-    // Reject non-TSP+decomp up front; the deep check only fires after all the geometry work.
-    if (do_decomp && goal->generate_route && !route_gen_->resolvesToTsp(goal->route_mode)) {
+    // Reject CUSTOM+decomp up front; the deep check only fires after all the geometry work.
+    if (do_decomp && goal->generate_route && route_gen_->resolvesToCustom(goal->route_mode)) {
       throw CoverageException(
-              "Non-TSP route modes are not supported with field decomposition; "
-              "use route_mode TSP or disable decomposition.");
+              "CUSTOM route mode is not supported with field decomposition; the order "
+              "vector cannot be split across cells. Use another route mode or disable it.");
     }
 
     Field field_no_headland = field;

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <cmath>
 #include <vector>
 #include <string>
@@ -20,6 +21,25 @@
 
 namespace opennav_coverage
 {
+
+namespace
+{
+
+// Perpendicular distance from p to the segment [a, b].
+double distanceToSegment(const Point & p, const Point & a, const Point & b)
+{
+  const double dx = b.getX() - a.getX();
+  const double dy = b.getY() - a.getY();
+  const double len2 = dx * dx + dy * dy;
+  if (len2 < 1e-12) {
+    return p.distance(a);
+  }
+  const double t = std::clamp(
+    ((p.getX() - a.getX()) * dx + (p.getY() - a.getY()) * dy) / len2, 0.0, 1.0);
+  return std::hypot(p.getX() - (a.getX() + t * dx), p.getY() - (a.getY() + t * dy));
+}
+
+}  // namespace
 
 Path PathGenerator::generatePath(
   const F2CRoute & route, const opennav_coverage_msgs::msg::PathMode & settings)
@@ -118,15 +138,16 @@ void PathGenerator::appendConnection(
     }
   }
 
-  double polyline_len = 0.0;
-  for (size_t i = 0; i + 1 < pts.size(); ++i) {
-    polyline_len += pts[i].distance(pts[i + 1]);
+  // Deviation, not length ratio: rounding a long cell's corner is only ~20%
+  // longer than cutting its diagonal, yet shares no ground with it.
+  double max_dev = 0.0;
+  for (size_t i = 1; i + 1 < pts.size(); ++i) {
+    max_dev = std::max(max_dev, distanceToSegment(pts[i], pts.front(), pts.back()));
   }
-  const double direct_len = pts.front().distance(pts.back());
 
-  // Near-straight hop between two swath groups: one curve (the u-turn). Boundary
-  // connections (to/from a TSP start point) fall through to keep that point.
-  if (has_prev && has_next && polyline_len < 1.3 * std::max(direct_len, 1e-6)) {
+  // Straight hop: the ordinary headland u-turn, leave it to the curve planner.
+  // A real bend means the graph routed around something worth keeping.
+  if (has_prev && has_next && max_dev < 0.5 * robot_params_->getOperationWidth()) {
     path += curve.createTurn(
       robot, prev.back().endPoint(), prev.back().getOutAngle(),
       next[0].startPoint(), next[0].getInAngle());

--- a/opennav_coverage/src/route_generator.cpp
+++ b/opennav_coverage/src/route_generator.cpp
@@ -51,8 +51,10 @@ F2CRoute RouteGenerator::generateRoute(
             "No valid route mode set! Options: BOUSTROPHEDON, SNAKE, SPIRAL, CUSTOM, TSP.");
   }
 
-  if (start_end && action_type != RouteType::TSP) {
-    RCLCPP_WARN(logger_, "start_pose ignored: only used in TSP route mode.");
+  // Multi-cell non-TSP honours start_end via the stitch layer (nearest cell only);
+  // single-cell orderers have no way to use it.
+  if (start_end && action_type != RouteType::TSP && swath_cells.size() <= 1) {
+    RCLCPP_WARN(logger_, "start_pose ignored: single-cell non-TSP route modes cannot use it.");
   }
 
   RCLCPP_DEBUG(logger_, "Generating route: %s", toString(action_type).c_str());
@@ -70,16 +72,16 @@ RouteGeneratorPtr RouteGenerator::createGenerator(const RouteType & type)
   switch (type) {
     case RouteType::BOUSTROPHEDON:
       return std::make_shared<SwathOrderMethod>(
-        type, std::make_shared<f2c::rp::BoustrophedonOrder>());
+        logger_, type, std::make_shared<f2c::rp::BoustrophedonOrder>());
     case RouteType::SNAKE:
       return std::make_shared<SwathOrderMethod>(
-        type, std::make_shared<f2c::rp::SnakeOrder>());
+        logger_, type, std::make_shared<f2c::rp::SnakeOrder>());
     case RouteType::SPIRAL:
       return std::make_shared<SwathOrderMethod>(
-        type, std::make_shared<f2c::rp::SpiralOrder>());
+        logger_, type, std::make_shared<f2c::rp::SpiralOrder>());
     case RouteType::CUSTOM:
       return std::make_shared<SwathOrderMethod>(
-        type, std::make_shared<f2c::rp::CustomOrder>());
+        logger_, type, std::make_shared<f2c::rp::CustomOrder>());
     case RouteType::TSP:
       return std::make_shared<TspRouteMethod>(
         logger_, static_cast<size_t>(default_max_swaths_for_global_route_));

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -16,6 +16,8 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -57,21 +59,33 @@ F2CRoute reversedRoute(const F2CRoute & route)
   return out;
 }
 
+// Fallback matches RouteMode.msg's tsp_d_tol default; the stitch needs a positive tolerance.
+constexpr double kDefaultDTol = 1e-4;
+
+// Orders per-cell routes nearest-neighbour (heading-aware) and bridges them along
+// the travel-cell border graph. Independent of how each cell route was planned.
+F2CRoute stitchCellRoutes(
+  const F2CCells & travel_cells,
+  const std::vector<F2CRoute> & cell_routes,
+  const std::optional<F2CPoint> & start_end,
+  double d_tol,
+  const rclcpp::Logger & logger);
+
 }  // namespace
 
 F2CRoute SwathOrderMethod::plan(
-  const F2CCells & /*travel_cells*/,
+  const F2CCells & travel_cells,
   const F2CCells & swath_cells,
   const F2CSwathsByCells & swaths_by_cells,
   const opennav_coverage_msgs::msg::RouteMode & settings,
-  // start_end is a TSP-only concept; the generator already warns the user, so it is ignored here
-  const std::optional<F2CPoint> & /*start_end*/)
+  const std::optional<F2CPoint> & start_end)
 {
-  // These orderers assume a single cell; multi-cell input breaks their ordering.
-  if (swath_cells.size() > 1) {
+  // CUSTOM indexes swaths absolutely and validates the vector length, so one
+  // order vector cannot be split across cells.
+  if (type_ == RouteType::CUSTOM && swath_cells.size() > 1) {
     throw CoverageException(
-            "Non-TSP route modes are not supported with field decomposition; "
-            "use route_mode TSP or disable decomposition.");
+            "CUSTOM route mode is not supported with field decomposition; the order "
+            "vector cannot be split across cells. Use another route mode or disable it.");
   }
 
   if (type_ == RouteType::SPIRAL) {
@@ -81,12 +95,25 @@ F2CRoute SwathOrderMethod::plan(
     dynamic_cast<f2c::rp::CustomOrder *>(orderer_.get())->setCustomOrder(custom_order);
   }
 
-  F2CSwaths ordered = orderer_->genSortedSwaths(swaths_by_cells.flatten());
+  // Single cell: unchanged behaviour, one genSortedSwaths call over the flattened swaths.
+  if (swath_cells.size() <= 1) {
+    F2CSwaths ordered = orderer_->genSortedSwaths(swaths_by_cells.flatten());
+    F2CRoute route;
+    route.addConnectedSwaths(F2CMultiPoint(), ordered);
+    return route;
+  }
 
-  // Wrap ordered swaths in a single-group route so every mode returns F2CRoute.
-  F2CRoute route;
-  route.addConnectedSwaths(F2CMultiPoint(), ordered);
-  return route;
+  // Multi-cell: order each cell alone. Flattening first would collide the
+  // per-cell swath ids that genSortedSwaths sorts on, interleaving the cells.
+  std::vector<F2CRoute> cell_routes(swath_cells.size());
+  for (size_t i = 0; i < swath_cells.size() && i < swaths_by_cells.size(); ++i) {
+    if (swaths_by_cells.at(i).size() == 0) {
+      continue;
+    }
+    cell_routes[i].addConnectedSwaths(
+      F2CMultiPoint(), orderer_->genSortedSwaths(swaths_by_cells.at(i)));
+  }
+  return stitchCellRoutes(travel_cells, cell_routes, start_end, settings.tsp_d_tol, logger_);
 }
 
 F2CRoute TspRouteMethod::plan(
@@ -131,6 +158,21 @@ F2CRoute TspRouteMethod::plan(
     cell_routes[i] = rp.genRoute(
       cell, cell_swaths, false, d_tol, redirect_swaths, time_limit, search_for_optimum);
   }
+
+  return stitchCellRoutes(travel_cells, cell_routes, start_end, d_tol, logger_);
+}
+
+namespace
+{
+
+F2CRoute stitchCellRoutes(
+  const F2CCells & travel_cells,
+  const std::vector<F2CRoute> & cell_routes,
+  const std::optional<F2CPoint> & start_end,
+  double d_tol,
+  const rclcpp::Logger & logger)
+{
+  const double tol = d_tol > 0.0 ? d_tol : kDefaultDTol;
 
   std::vector<size_t> remaining;
   for (size_t i = 0; i < cell_routes.size(); ++i) {
@@ -180,7 +222,7 @@ F2CRoute TspRouteMethod::plan(
   bool current_reversed = false;
   if (start_end) {
     RCLCPP_WARN(
-      logger_,
+      logger,
       "Multi-cell route: start_pose picks the nearest cell; the route starts at "
       "that cell's own start, not at the exact point.");
     current = pickNearest(*start_end, std::nullopt, current_reversed);
@@ -188,7 +230,7 @@ F2CRoute TspRouteMethod::plan(
 
   // Bridges follow the travel-cell pair's border graph, not a line that could cut a void.
   const auto buildBridge =
-    [&travel_cells, d_tol](
+    [&travel_cells, tol](
     const F2CSwath & from_swath, const F2CSwath & to_swath,
     const F2CPoint & from, const F2CPoint & to) {
       F2CSwaths end_swaths;
@@ -198,11 +240,11 @@ F2CRoute TspRouteMethod::plan(
       bridge_swaths.emplace_back(end_swaths);
 
       const auto viaGraph =
-        [&bridge_swaths, d_tol, &from, &to](const F2CCells & graph_cells) {
+        [&bridge_swaths, tol, &from, &to](const F2CCells & graph_cells) {
           std::vector<F2CPoint> pts;
           try {
             f2c::rp::RoutePlannerBase rp;
-            F2CGraph2D graph = rp.createShortestGraph(graph_cells, bridge_swaths, d_tol);
+            F2CGraph2D graph = rp.createShortestGraph(graph_cells, bridge_swaths, tol);
             pts = graph.shortestPath(from, to);
           } catch (const std::exception &) {
             pts.clear();
@@ -263,5 +305,7 @@ F2CRoute TspRouteMethod::plan(
   }
   return merged;
 }
+
+}  // namespace
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -303,8 +303,10 @@ F2CRoute stitchCellRoutes(
         pair_cells.addGeometry(cell_b);
       }
 
+      // Both endpoints must have landed in a cell: a one-cell graph still returns
+      // a plausible path, reaching the far endpoint by jumping off that border.
       std::vector<F2CPoint> bridge;
-      if (pair_cells.size() > 0) {
+      if (pair_cells.size() == 2) {
         bridge = viaGraph(pair_cells);
       }
       if (bridge.size() < 2) {

--- a/opennav_coverage/src/route_method.cpp
+++ b/opennav_coverage/src/route_method.cpp
@@ -62,6 +62,45 @@ F2CRoute reversedRoute(const F2CRoute & route)
 // Fallback matches RouteMode.msg's tsp_d_tol default; the stitch needs a positive tolerance.
 constexpr double kDefaultDTol = 1e-4;
 
+// Joins consecutive swaths along the cell's border graph. A naked turn ignores
+// the boundary, so a SNAKE/SPIRAL skip cuts across already-covered ground.
+F2CRoute routeThroughCell(
+  const Field & cell_geom, const Swaths & ordered, double d_tol,
+  const rclcpp::Logger & logger)
+{
+  F2CCells cell;
+  cell.addGeometry(cell_geom);
+  F2CSwathsByCells cell_swaths;
+  cell_swaths.emplace_back(ordered);
+
+  try {
+    f2c::rp::RoutePlannerBase rp;
+    F2CGraph2D graph = rp.createShortestGraph(cell, cell_swaths, d_tol);
+
+    // Per-pair fallback: shortestPath throws on a non-node endpoint, and one such
+    // pair must not cost the whole cell its connections.
+    F2CRoute route;
+    for (size_t i = 0; i < ordered.size(); ++i) {
+      if (i > 0) {
+        std::vector<F2CPoint> conn;
+        try {
+          conn = graph.shortestPath(route.endPoint(), ordered.at(i).startPoint());
+        } catch (const std::exception &) {
+          conn.clear();
+        }
+        route.addConnection(conn);
+      }
+      route.addSwath(ordered.at(i));
+    }
+    return route;
+  } catch (const std::exception & e) {
+    RCLCPP_WARN(logger, "Cell border graph failed (%s); using plain turns.", e.what());
+    F2CRoute plain;
+    plain.addConnectedSwaths(F2CMultiPoint(), ordered);
+    return plain;
+  }
+}
+
 // Orders per-cell routes nearest-neighbour (heading-aware) and bridges them along
 // the travel-cell border graph. Independent of how each cell route was planned.
 F2CRoute stitchCellRoutes(
@@ -105,15 +144,17 @@ F2CRoute SwathOrderMethod::plan(
 
   // Multi-cell: order each cell alone. Flattening first would collide the
   // per-cell swath ids that genSortedSwaths sorts on, interleaving the cells.
+  const double d_tol = settings.tsp_d_tol > 0.0 ? settings.tsp_d_tol : kDefaultDTol;
   std::vector<F2CRoute> cell_routes(swath_cells.size());
   for (size_t i = 0; i < swath_cells.size() && i < swaths_by_cells.size(); ++i) {
     if (swaths_by_cells.at(i).size() == 0) {
       continue;
     }
-    cell_routes[i].addConnectedSwaths(
-      F2CMultiPoint(), orderer_->genSortedSwaths(swaths_by_cells.at(i)));
+    cell_routes[i] = routeThroughCell(
+      swath_cells.getGeometry(i), orderer_->genSortedSwaths(swaths_by_cells.at(i)),
+      d_tol, logger_);
   }
-  return stitchCellRoutes(travel_cells, cell_routes, start_end, settings.tsp_d_tol, logger_);
+  return stitchCellRoutes(travel_cells, cell_routes, start_end, d_tol, logger_);
 }
 
 F2CRoute TspRouteMethod::plan(

--- a/opennav_coverage/test/test_route.cpp
+++ b/opennav_coverage/test/test_route.cpp
@@ -363,9 +363,8 @@ TEST(RouteTests, TestTSPMultiCellStartPoint)
 
 TEST(RouteTests, TestSwathOrderMultiCellNotInterleaved)
 {
-  // Regression: non-TSP multi-cell must finish one cell before starting the
-  // other. Membership is geometric (midpoint side of x=s), not swath id,
-  // since ids are per-cell and collide across cells.
+  // Cells must not interleave. Membership is geometric, not by swath id: ids are
+  // per-cell and collide across cells.
   auto node = std::make_shared<rclcpp::Node>("test_node");
   RobotParams robot_params(node);
   SwathGenerator swath_gen(node, &robot_params);
@@ -437,6 +436,27 @@ TEST(RouteTests, TestSwathOrderMultiCellBridged)
     }
   }
   EXPECT_TRUE(has_bridge);
+}
+
+TEST(RouteTests, TestSwathOrderMultiCellConnectsWithinCell)
+{
+  // Transitions inside a cell must follow its border graph, which puts every
+  // swath in its own connected group.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeTwoAdjacentCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "SPIRAL";
+  settings.spiral_n = 2;
+  F2CRoute route = generator.generateRoute(cells, sbc, settings);
+
+  EXPECT_EQ(route.sizeVectorSwaths(), sbc.sizeTotal());
 }
 
 TEST(RouteTests, TestSwathOrderMultiCellModes)

--- a/opennav_coverage/test/test_route.cpp
+++ b/opennav_coverage/test/test_route.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "opennav_coverage/robot_params.hpp"
@@ -357,6 +359,144 @@ TEST(RouteTests, TestTSPMultiCellStartPoint)
   settings.tsp_time_limit = 1;
   F2CRoute route = generator.generateRoute(cells, sbc, settings, F2CPoint(0.0, 0.0));
   EXPECT_FALSE(route.isEmpty());
+}
+
+TEST(RouteTests, TestSwathOrderMultiCellNotInterleaved)
+{
+  // Regression: non-TSP multi-cell must finish one cell before starting the
+  // other. Membership is geometric (midpoint side of x=s), not swath id,
+  // since ids are per-cell and collide across cells.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  const double s = 100.0;
+  F2CCells cells = makeTwoAdjacentCells(s);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+  ASSERT_GE(sbc.size(), 2u);  // one swath group per cell
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "BOUSTROPHEDON";
+  F2CRoute route = generator.generateRoute(cells, sbc, settings);
+
+  EXPECT_FALSE(route.isEmpty());
+  EXPECT_GE(route.sizeVectorSwaths(), 2u);
+
+  std::vector<int> sides;
+  size_t total_out = 0;
+  for (size_t g = 0; g < route.sizeVectorSwaths(); ++g) {
+    for (const auto & swath : route.getVectorSwaths()[g]) {
+      const double mid_x = (swath.startPoint().getX() + swath.endPoint().getX()) / 2.0;
+      sides.push_back(mid_x < s ? 0 : 1);
+      ++total_out;
+    }
+  }
+  EXPECT_EQ(sbc.sizeTotal(), total_out);
+
+  // Both cells must actually appear, or the no-crossing-back check below is vacuous.
+  ASSERT_TRUE(
+    std::any_of(sides.begin(), sides.end(), [](int v) {return v == 0;}) &&
+    std::any_of(sides.begin(), sides.end(), [](int v) {return v == 1;}));
+
+  // Once the route crosses to the other cell, it must never cross back.
+  size_t switch_idx = sides.size();
+  for (size_t i = 1; i < sides.size(); ++i) {
+    if (sides[i] != sides[0]) {
+      switch_idx = i;
+      break;
+    }
+  }
+  for (size_t i = switch_idx; i < sides.size(); ++i) {
+    EXPECT_EQ(sides[i], sides[switch_idx]) << "cells interleaved at swath index " << i;
+  }
+}
+
+TEST(RouteTests, TestSwathOrderMultiCellBridged)
+{
+  // Multi-cell non-TSP must bridge cells via the stitch layer, not leave a gap.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeTwoAdjacentCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "BOUSTROPHEDON";
+  F2CRoute route = generator.generateRoute(cells, sbc, settings);
+
+  bool has_bridge = false;
+  for (const auto & conn : route.getConnections()) {
+    if (conn.size() > 0) {
+      has_bridge = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(has_bridge);
+}
+
+TEST(RouteTests, TestSwathOrderMultiCellModes)
+{
+  // SNAKE and SPIRAL must also plan multi-cell without throwing, like BOUSTROPHEDON.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeTwoAdjacentCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "SNAKE";
+  F2CRoute snake_route = generator.generateRoute(cells, sbc, settings);
+  EXPECT_FALSE(snake_route.isEmpty());
+
+  settings.mode = "SPIRAL";
+  settings.spiral_n = 2;
+  F2CRoute spiral_route = generator.generateRoute(cells, sbc, settings);
+  EXPECT_FALSE(spiral_route.isEmpty());
+}
+
+TEST(RouteTests, TestCustomOrderMultiCellRejected)
+{
+  // CUSTOM's order vector can't be split across cells; multi-cell must throw.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeTwoAdjacentCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "CUSTOM";
+  EXPECT_THROW(generator.generateRoute(cells, sbc, settings), CoverageException);
+}
+
+TEST(RouteTests, TestSwathOrderSingleCellUnchanged)
+{
+  // Guards the single-cell fast path: still one group with the full swath count.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  SwathGenerator swath_gen(node, &robot_params);
+  RouteShim generator(node);
+
+  F2CCells cells = makeSquareCells(100.0);
+  opennav_coverage_msgs::msg::SwathMode sw_settings;
+  F2CSwathsByCells sbc = swath_gen.generateSwathsByCells(cells, sw_settings);
+
+  opennav_coverage_msgs::msg::RouteMode settings;
+  settings.mode = "BOUSTROPHEDON";
+  F2CRoute route = generator.generateRoute(cells, sbc, settings);
+
+  EXPECT_EQ(route.sizeVectorSwaths(), 1u);
+  EXPECT_EQ(route.getVectorSwaths()[0].size(), sbc.sizeTotal());
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_server.cpp
+++ b/opennav_coverage/test/test_server.cpp
@@ -193,9 +193,9 @@ TEST(ServerTest, testDecompPath)
   EXPECT_EQ(result.code, rclcpp_action::ResultCode::SUCCEEDED);
 }
 
-TEST(ServerTest, testDecompNonTSPRouteRejected)
+TEST(ServerTest, testDecompCustomRouteRejected)
 {
-  // Non-TSP route modes only handle a single cell, so combining one with
+  // CUSTOM's order vector can't be split across cells, so combining it with
   // decomposition (multi-cell) must be rejected with INVALID_MODE_SET.
   auto node = std::make_shared<ServerShim>();
   rclcpp_lifecycle::State state;
@@ -203,7 +203,7 @@ TEST(ServerTest, testDecompNonTSPRouteRejected)
   node->activate(state);
   auto node_thread = std::make_unique<nav2::NodeThread>(node);
 
-  auto client_node = std::make_shared<rclcpp::Node>("my_node_decomp_nontsp");
+  auto client_node = std::make_shared<rclcpp::Node>("my_node_decomp_custom");
   auto action_client =
     rclcpp_action::create_client<opennav_coverage_msgs::action::ComputeCoveragePath>(
     client_node, "compute_coverage_path");
@@ -215,7 +215,7 @@ TEST(ServerTest, testDecompNonTSPRouteRejected)
   goal_msg.decomp_mode.mode = "TRAPEZOIDAL";
   goal_msg.generate_headland = true;
   goal_msg.generate_route = true;
-  goal_msg.route_mode.mode = "BOUSTROPHEDON";  // non-TSP -> rejected with decomposition
+  goal_msg.route_mode.mode = "CUSTOM";  // order vector -> rejected with decomposition
   goal_msg.generate_path = true;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
### Motivation

BOUSTROPHEDON, SNAKE, and SPIRAL were rejected whenever decomposition produced
multiple cells. The restriction came from #119, before this package had its own
per-cell stitching layer; #137 built that layer for TSP and the rejection was
never revisited. Since `default_route_type` is BOUSTROPHEDON, enabling
`generate_decomp` with stock parameters threw `INVALID_MODE_SET`.

### Changes

**Enable the swath-order modes for multi-cell fields.** Flattening the per-cell
swaths before ordering collided their per-cell ids and interleaved the cells, so
each cell is now ordered on its own and handed to the same stitch layer TSP uses
(extracted from `TspRouteMethod`). CUSTOM stays rejected — its order vector
indexes swaths absolutely and cannot be split across cells.

Two connection bugs surfaced while validating this in RViz. Both predate the
branch and both affect TSP as well:

**Cell-internal transitions ignored the boundary.** Each cell's swaths were
wrapped in a single connection-less group, so every transition became a naked
Dubins turn and a SNAKE/SPIRAL skip cut across covered ground. Cells now route
through F2C's shortest-path graph, connecting every consecutive swath pair.

**The detour test used a length ratio.** A connection collapsed to a single turn
below 1.3x the direct distance, which cannot separate a u-turn from a detour —
rounding a long cell's corner is only ~20% longer than cutting its diagonal. One
measured 36.3 m of polyline against 30.7 m direct and became a 30 m diagonal.
Peak deviation from the straight hop is now the criterion.

**Bridges trusted a half-resolved cell pair.** `getCellWherePoint` can miss an
endpoint sitting on a cell border. The graph was still built from the single
remaining cell and reached the far endpoint by jumping off its border. Since the
result had ≥2 points it counted as a success and the whole-set fallback never ran.

### Testing

Unit tests cover multi-cell ordering, SNAKE/SPIRAL planning, CUSTOM rejection,
and the unchanged single-cell path. Verified in RViz on concave E- and
zigzag-shaped fields across all modes.
