### PR TITLE
Follow and smooth the connections between swath groups

### DIFF
--- a/opennav_coverage/include/opennav_coverage/path_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/path_generator.hpp
@@ -70,6 +70,12 @@ public:
       node, "default_reduce_min_dist", rclcpp::ParameterValue(0.1));
     reduce_min_dist_ = node->get_parameter("default_reduce_min_dist").as_double();
 
+    // Defaults to the ground the implement already covers either side of a swath.
+    nav2::declare_parameter_if_not_declared(
+      node, "corner_cut_tolerance",
+      rclcpp::ParameterValue(0.5 * robot_params->getOperationWidth()));
+    corner_cut_tol_ = node->get_parameter("corner_cut_tolerance").as_double();
+
     // Path Generator requires no changes at runtime
     generator_ = std::make_unique<f2c::pp::PathPlanning>();
     default_curve_ = createCurve(default_type_, default_continuity_type_);
@@ -127,6 +133,12 @@ public:
    * @param setting double minimum distance between kept points
    */
   void setReduceMinDist(const double & setting) {reduce_min_dist_ = setting;}
+
+  /**
+   * @brief Sets how far rounding a connection's corner may leave the track
+   * @param setting double tolerance in meters
+   */
+  void setCornerCutTolerance(const double & setting) {corner_cut_tol_ = setting;}
 
 protected:
   /**
@@ -186,6 +198,7 @@ protected:
   float default_turn_point_distance_;
   bool reduce_path_;
   double reduce_min_dist_;
+  double corner_cut_tol_;
   TurningBasePtr default_curve_;
   std::unique_ptr<f2c::pp::PathPlanning> generator_;
   RobotParams * robot_params_;

--- a/opennav_coverage/include/opennav_coverage/path_generator.hpp
+++ b/opennav_coverage/include/opennav_coverage/path_generator.hpp
@@ -85,6 +85,18 @@ public:
     const F2CRoute & route, const opennav_coverage_msgs::msg::PathMode & settings);
 
   /**
+   * @brief Turns planned for the connections of the last generatePath call, one
+   *        Path per maneuver, for debug visualization
+   * @return Connection turns, empty if the connections were all straight
+   */
+  const std::vector<Path> & getConnectionTurns() const {return connection_turns_;}
+
+  /**
+   * @brief Drops the turns held for visualization, for a request that plans no path
+   */
+  void clearConnectionTurns() {connection_turns_.clear();}
+
+  /**
    * @brief Sets the mode manually of the paths for dynamic parameters
    * @param mode String for mode to use
    */
@@ -123,9 +135,11 @@ protected:
    *        handed to F2C's own route-level planPath).
    * @param route Route with ordered swath groups and connections
    * @param curve Curve generator for turns
+   * @param sharp_corners Out: connection corners no turn could be fitted through
    * @return Full path
    */
-  Path assemblePath(const F2CRoute & route, f2c::pp::TurningBase & curve);
+  Path assemblePath(
+    const F2CRoute & route, f2c::pp::TurningBase & curve, size_t & sharp_corners);
 
   /**
    * @brief Append one connection between swath groups to the path
@@ -133,9 +147,10 @@ protected:
    * @param prev Previous swath group (may be empty at the route start)
    * @param connection Connection waypoints from the route (may be empty)
    * @param next Next swath group (may be empty at the route end)
-   * @param curve Curve generator used when there is no polyline to follow
+   * @param curve Curve generator for the u-turn, or for the polyline's corners
+   * @return Corners left sharp because no turn fit within the track's corridor
    */
-  void appendConnection(
+  size_t appendConnection(
     Path & path, const Swaths & prev, const F2CMultiPoint & connection,
     const Swaths & next, f2c::pp::TurningBase & curve);
 
@@ -174,6 +189,9 @@ protected:
   TurningBasePtr default_curve_;
   std::unique_ptr<f2c::pp::PathPlanning> generator_;
   RobotParams * robot_params_;
+  // Continuity of the curve in use, which sets how tight a turn can actually be
+  PathContinuityType active_continuity_type_{PathContinuityType::UNKNOWN};
+  std::vector<Path> connection_turns_;
   rclcpp::Logger logger_{rclcpp::get_logger("SwathGenerator")};
 };
 

--- a/opennav_coverage/include/opennav_coverage/utils.hpp
+++ b/opennav_coverage/include/opennav_coverage/utils.hpp
@@ -16,6 +16,7 @@
 #define OPENNAV_COVERAGE__UTILS_HPP_
 
 #include <cmath>
+#include <limits>
 #include <vector>
 #include <string>
 #include <algorithm>
@@ -34,6 +35,147 @@ namespace opennav_coverage
 
 namespace util
 {
+
+/**
+ * @brief Spreadsheet-style label for a connection turn: A..Z, then AA, AB, ...
+ *        Names a turn the same way in the debug log and in RViz
+ * @param idx Index of the turn
+ * @return Label
+ */
+inline std::string turnLabel(size_t idx)
+{
+  std::string label;
+  do {
+    label.insert(label.begin(), static_cast<char>('A' + idx % 26));
+    idx = idx / 26;
+  } while (idx-- > 0);
+  return label;
+}
+
+/**
+ * @brief Magnitude of the turn from one heading to another, wrapped to [0, pi]
+ * @param from Heading turned from
+ * @param to Heading turned to
+ * @return Turn magnitude
+ */
+inline double sweepBetween(double from, double to)
+{
+  const double d = to - from;
+  return std::fabs(std::atan2(std::sin(d), std::cos(d)));
+}
+
+/**
+ * @brief Perpendicular distance from a point to a segment
+ * @param p Point measured
+ * @param a Start of the segment
+ * @param b End of the segment
+ * @return Distance, to the nearer end when the segment is degenerate
+ */
+inline double distanceToSegment(const Point & p, const Point & a, const Point & b)
+{
+  const double dx = b.getX() - a.getX();
+  const double dy = b.getY() - a.getY();
+  const double len2 = dx * dx + dy * dy;
+  if (len2 < 1e-12) {
+    return p.distance(a);
+  }
+  const double t = std::clamp(
+    ((p.getX() - a.getX()) * dx + (p.getY() - a.getY()) * dy) / len2, 0.0, 1.0);
+  return std::hypot(p.getX() - (a.getX() + t * dx), p.getY() - (a.getY() + t * dy));
+}
+
+/**
+ * @brief Point a given distance from one point towards another
+ * @param from Point measured from
+ * @param to Point measured towards
+ * @param dist Distance along
+ * @return Point, or `from` when the two coincide
+ */
+inline Point pointAlong(const Point & from, const Point & to, double dist)
+{
+  const double len = from.distance(to);
+  if (len < 1e-9) {
+    return from;
+  }
+  return Point(
+    from.getX() + (to.getX() - from.getX()) * dist / len,
+    from.getY() + (to.getY() - from.getY()) * dist / len);
+}
+
+/**
+ * @brief Drops repeated points and those that only subdivide a straight run
+ *
+ * Douglas-Peucker, so every dropped point stays within `tol` of what is kept.
+ * Iterative rather than recursive: the depth would follow the point count on a
+ * staircase, which is what a decomposed field's border rings are.
+ * @param pts Polyline to thin
+ * @param tol Furthest a dropped point may sit from what is kept
+ * @return Thinned polyline, ends preserved
+ */
+inline std::vector<Point> simplifyPolyline(const std::vector<Point> & pts, double tol)
+{
+  std::vector<Point> uniq;
+  for (const auto & p : pts) {
+    if (uniq.empty() || uniq.back().distance(p) > 1e-6) {
+      uniq.push_back(p);
+    }
+  }
+  if (uniq.size() < 3) {
+    return uniq;
+  }
+
+  std::vector<bool> keep(uniq.size(), false);
+  keep.front() = true;
+  keep.back() = true;
+  std::vector<std::pair<size_t, size_t>> ranges{{0, uniq.size() - 1}};
+  while (!ranges.empty()) {
+    const size_t lo = ranges.back().first;
+    const size_t hi = ranges.back().second;
+    ranges.pop_back();
+
+    double worst = 0.0;
+    size_t split = lo;
+    for (size_t i = lo + 1; i < hi; ++i) {
+      const double dev = distanceToSegment(uniq[i], uniq[lo], uniq[hi]);
+      if (dev > worst) {
+        worst = dev;
+        split = i;
+      }
+    }
+    if (worst > tol) {
+      keep[split] = true;
+      ranges.push_back({lo, split});
+      ranges.push_back({split, hi});
+    }
+  }
+
+  std::vector<Point> out;
+  for (size_t i = 0; i < uniq.size(); ++i) {
+    if (keep[i]) {
+      out.push_back(uniq[i]);
+    }
+  }
+  return out;
+}
+
+/**
+ * @brief Furthest any state of a path strays from the polyline it stands in for
+ * @param arc Path measured
+ * @param track Polyline it replaces
+ * @return Worst deviation
+ */
+inline double deviationFromTrack(const Path & arc, const std::vector<Point> & track)
+{
+  double worst = 0.0;
+  for (const auto & s : arc.getStates()) {
+    double nearest = std::numeric_limits<double>::max();
+    for (size_t k = 0; k + 1 < track.size(); ++k) {
+      nearest = std::min(nearest, distanceToSegment(s.point, track[k], track[k + 1]));
+    }
+    worst = std::max(worst, nearest);
+  }
+  return worst;
+}
 
 /**
  * @brief Converts F2C Point to ROS Point32

--- a/opennav_coverage/include/opennav_coverage/visualizer.hpp
+++ b/opennav_coverage/include/opennav_coverage/visualizer.hpp
@@ -28,6 +28,7 @@
 #include "geometry_msgs/msg/polygon_stamped.hpp"
 #include "nav_msgs/msg/path.hpp"
 #include "visualization_msgs/msg/marker.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
 
 namespace opennav_coverage
 {
@@ -59,6 +60,9 @@ public:
     headland_swaths_pub_ = rclcpp::create_publisher<visualization_msgs::msg::Marker>(
       node->get_node_topics_interface(),
       "coverage_server/headland_swaths", rclcpp::QoS(1));
+    connection_turns_pub_ = rclcpp::create_publisher<visualization_msgs::msg::MarkerArray>(
+      node->get_node_topics_interface(),
+      "coverage_server/connection_turns", rclcpp::QoS(1));
   }
 
   void deactivate();
@@ -67,13 +71,15 @@ public:
     const Field & total_field, const Field & no_headland_field,
     const Point & ref_pt, const nav_msgs::msg::Path & path,
     const Swaths swaths, const std_msgs::msg::Header & header,
-    const Path & headland_path = Path());
+    const Path & headland_path = Path(),
+    const std::vector<Path> & connection_turns = {});
 
   rclcpp::Publisher<nav_msgs::msg::Path>::SharedPtr nav_plan_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr headlands_pub_;
   rclcpp::Publisher<geometry_msgs::msg::PolygonStamped>::SharedPtr planning_field_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr swaths_pub_;
   rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr headland_swaths_pub_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr connection_turns_pub_;
 };
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -174,6 +174,10 @@ void CoverageServer::computeCoveragePath()
   }
 
   try {
+    // A request that plans no path draws no turns; the last one's are otherwise
+    // still held and would be published over the new field.
+    path_gen_->clearConnectionTurns();
+
     // (0) Obtain field to use
     Field field;
     F2CField master_field;
@@ -329,7 +333,7 @@ void CoverageServer::computeCoveragePath()
     visualizer_->visualize(
       field, field_no_headland, master_field.getRefPoint(),
       util::toCartesianNavPathMsg(path, header, path_gen_->getTurnPointDistance()),
-      swaths, header, headland_path);
+      swaths, header, headland_path, path_gen_->getConnectionTurns());
     action_server_->succeeded_current(result);
   } catch (CoverageException & e) {
     RCLCPP_ERROR(get_logger(), "Invalid mode set: %s", e.what());

--- a/opennav_coverage/src/coverage_server.cpp
+++ b/opennav_coverage/src/coverage_server.cpp
@@ -369,6 +369,8 @@ CoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> paramet
         path_gen_->setTurnPointDistance(parameter.as_double());
       } else if (name == "default_reduce_min_dist") {
         path_gen_->setReduceMinDist(parameter.as_double());
+      } else if (name == "corner_cut_tolerance") {
+        path_gen_->setCornerCutTolerance(parameter.as_double());
       } else if (name == "default_tsp_d_tol") {
         route_gen_->setTspDTol(parameter.as_double());
       } else if (name == "robot_width") {

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -278,9 +278,13 @@ size_t appendRoundedTrack(
           track.push_back(poly[k]);
         }
         track.push_back(exit);
+        // A u-turn swings past the vertices by up to the diameter it turns on,
+        // so it is allowed the corridor plus that rather than exempted.
         const double dev = util::deviationFromTrack(arc, track);
-        if (!uturn && dev > cut_tol) {
-          report("strays dev/max", back_off, dev, cut_tol);
+        const double dev_max = uturn ?
+          cut_tol + 2.0 * turnRadius(robot, net, continuous) : cut_tol;
+        if (dev > dev_max) {
+          report("strays dev/max", back_off, dev, dev_max);
           continue;
         }
 

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -32,7 +32,6 @@ namespace
 // Fractions of the operation width.
 constexpr double kDirectHopDev = 0.25;  // under this a connection is a plain u-turn
 constexpr double kSimplifyTol = 0.1;    // points this close to the track are dropped
-constexpr double kCornerCutTol = 0.5;   // how far a rounded corner may leave the track
 
 constexpr double kLegShare = 0.5;       // a leg is split evenly between its two corners
 constexpr double kMinSweep = 0.05;      // corners under ~3deg are driven straight through
@@ -82,12 +81,11 @@ double turnRadius(const Robot & robot, double sweep, bool continuous)
 // Returns the corners left sharp because no maneuver fit within `cut_tol`.
 size_t appendRoundedTrack(
   Path & path, const std::vector<Point> & poly, Robot & robot,
-  f2c::pp::TurningBase & curve, double op_width, bool continuous,
+  f2c::pp::TurningBase & curve, double op_width, double cut_tol, bool continuous,
   const std::optional<double> & start_angle, const std::optional<double> & end_angle,
   const rclcpp::Logger & logger, std::vector<Path> * turns)
 {
   const double radius = robot.getMinTurningRadius();
-  const double cut_tol = kCornerCutTol * op_width;
   const size_t n = poly.size();
   const auto legAngle = [&poly](size_t a, size_t b) {
       return std::atan2(poly[b].getY() - poly[a].getY(), poly[b].getX() - poly[a].getX());
@@ -355,8 +353,9 @@ Path PathGenerator::generatePath(
     RCLCPP_WARN(
       logger_,
       "%zu connection corner(s) left sharp: no turn fits within %.2fm of the track. "
-      "Widen operation_width or lower min_turning_radius if the controller cannot hold them.",
-      sharp_corners, kCornerCutTol * robot_params_->getOperationWidth());
+      "Raise corner_cut_tolerance or lower min_turning_radius if the controller cannot "
+      "hold them.",
+      sharp_corners, corner_cut_tol_);
   }
 
   // Optionally thin out near-duplicate points (e.g. in turns)
@@ -483,7 +482,7 @@ size_t PathGenerator::appendConnection(
   const std::optional<double> end_angle = has_next ?
     std::optional<double>(next[0].getInAngle()) : std::nullopt;
   return appendRoundedTrack(
-    path, poly, robot, curve, op_width, continuous, start_angle, end_angle,
+    path, poly, robot, curve, op_width, corner_cut_tol_, continuous, start_angle, end_angle,
     logger_, &connection_turns_);
 }
 

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -342,6 +342,8 @@ Path PathGenerator::generatePath(
   if (!curve) {
     throw CoverageException("No valid path mode set!");
   }
+  // The corner maths sizes its turns off this, and it is only resolved here.
+  active_continuity_type_ = action_continuity_type;
 
   RCLCPP_INFO(
     logger_,

--- a/opennav_coverage/src/path_generator.cpp
+++ b/opennav_coverage/src/path_generator.cpp
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <limits>
+#include <optional>
+#include <utility>
 #include <vector>
 #include <string>
 
@@ -25,18 +29,287 @@ namespace opennav_coverage
 namespace
 {
 
-// Perpendicular distance from p to the segment [a, b].
-double distanceToSegment(const Point & p, const Point & a, const Point & b)
+// Fractions of the operation width.
+constexpr double kDirectHopDev = 0.25;  // under this a connection is a plain u-turn
+constexpr double kSimplifyTol = 0.1;    // points this close to the track are dropped
+constexpr double kCornerCutTol = 0.5;   // how far a rounded corner may leave the track
+
+constexpr double kLegShare = 0.5;       // a leg is split evenly between its two corners
+constexpr double kMinSweep = 0.05;      // corners under ~3deg are driven straight through
+constexpr double kRadiusMargin = 1.2;   // room for the clothoid lead-in of a CC turn
+constexpr double kMinBackoffRadii = 0.5;  // shallow corners still get a workable approach
+constexpr double kLoopSlackRadii = 2.0;   // over this the planner answered with a loop
+constexpr double kReversalSweep = 2.0;    // legs this far apart in heading double back
+constexpr double kUturnHopWidths = 3.0;   // a u-turn between neighbours spans about one
+constexpr double kUturnReachRadii = 4.0;  // how far back a u-turn may start, in radii
+constexpr size_t kMaxSpan = 3;            // a spur, the corner it leads to, and a spur out
+
+// Legs run along the border between swaths, so they are headland passes at
+// cruise speed rather than in-place turns.
+void addStraight(Path & path, Robot & robot, const Point & a, const Point & b)
 {
-  const double dx = b.getX() - a.getX();
-  const double dy = b.getY() - a.getY();
-  const double len2 = dx * dx + dy * dy;
-  if (len2 < 1e-12) {
-    return p.distance(a);
+  const double len = a.distance(b);
+  if (len < 1e-6) {
+    return;
   }
-  const double t = std::clamp(
-    ((p.getX() - a.getX()) * dx + (p.getY() - a.getY()) * dy) / len2, 0.0, 1.0);
-  return std::hypot(p.getX() - (a.getX() + t * dx), p.getY() - (a.getY() + t * dy));
+  PathState s;
+  s.point = a;
+  s.angle = std::atan2(b.getY() - a.getY(), b.getX() - a.getX());
+  s.len = len;
+  s.dir = f2c::types::PathDirection::FORWARD;
+  s.type = f2c::types::PathSectionType::HL_SWATH;
+  s.velocity = robot.getCruiseVel();
+  path.addState(s);
+}
+
+// Smallest radius a turn of `sweep` radians can be driven at. Each curvature
+// ramp of a continuous turn consumes curvature^2/(2*rate) of the deflection, so
+// below this the planner returns a curve that jumps to full curvature.
+double turnRadius(const Robot & robot, double sweep, bool continuous)
+{
+  const double min_radius = robot.getMinTurningRadius();
+  const double rate = robot.getMaxDiffCurv();
+  if (!continuous || rate <= 0.0 || sweep <= 0.0) {
+    return min_radius;
+  }
+  return std::max(min_radius, 1.0 / std::sqrt(rate * sweep));
+}
+
+// Follow `poly`: straight runs as they are, corners through the turn planner.
+// `start_angle`/`end_angle` are the headings the swaths either side hold, unset
+// where there is no swath. They stand in for the track's own direction, which
+// the robot does not hold there, making each end a corner in its own right.
+// Returns the corners left sharp because no maneuver fit within `cut_tol`.
+size_t appendRoundedTrack(
+  Path & path, const std::vector<Point> & poly, Robot & robot,
+  f2c::pp::TurningBase & curve, double op_width, bool continuous,
+  const std::optional<double> & start_angle, const std::optional<double> & end_angle,
+  const rclcpp::Logger & logger, std::vector<Path> * turns)
+{
+  const double radius = robot.getMinTurningRadius();
+  const double cut_tol = kCornerCutTol * op_width;
+  const size_t n = poly.size();
+  const auto legAngle = [&poly](size_t a, size_t b) {
+      return std::atan2(poly[b].getY() - poly[a].getY(), poly[b].getX() - poly[a].getX());
+    };
+
+  // Deflection at each corner, which is what sizes the maneuver through it.
+  std::vector<double> sweeps(n, 0.0);
+  for (size_t k = 1; k + 1 < n; ++k) {
+    sweeps[k] = util::sweepBetween(legAngle(k - 1, k), legAngle(k, k + 1));
+  }
+  if (start_angle) {
+    sweeps.front() = util::sweepBetween(*start_angle, legAngle(0, 1));
+  }
+  if (end_angle) {
+    sweeps.back() = util::sweepBetween(legAngle(n - 2, n - 1), *end_angle);
+  }
+
+  size_t sharp = 0;
+  Point cursor = poly.front();
+  size_t i = 0;
+  while (i < n) {
+    if (sweeps[i] < kMinSweep) {
+      addStraight(path, robot, cursor, poly[i]);
+      cursor = poly[i];
+      ++i;
+      continue;
+    }
+
+    // Corners closer together than a maneuver needs on either side cannot be
+    // taken one at a time: rounding the first leaves the next no approach. Fold
+    // those into a single span.
+    size_t min_span = 1;
+    while (i + min_span < n && min_span < kMaxSpan &&
+      sweeps[i + min_span] >= kMinSweep &&
+      poly[i + min_span - 1].distance(poly[i + min_span]) < 2.0 * kRadiusMargin * radius)
+    {
+      ++min_span;
+    }
+
+    bool rounded = false;
+    // Widening out from there, because a shorter span cuts less corner.
+    for (size_t span = min_span; span <= kMaxSpan && i + span <= n && !rounded; ++span) {
+      const size_t j = i + span - 1;               // last corner taken in one go
+      // At either end the pose is the swath's, fixed there rather than slid
+      // along a leg.
+      const bool pin_in = (i == 0);
+      const bool pin_out = (j + 1 == n);
+      if (pin_out && !end_angle) {
+        break;
+      }
+      const Point & first = poly[i];
+      const Point & last_corner = poly[j];
+      const Point & after = pin_out ? poly[j] : poly[j + 1];
+
+      // Total turning sizes the maneuver's length; net deflection sizes its
+      // geometry. They differ on an S, where the two corners cancel: summing
+      // magnitudes would read that as a reversal and refuse to plan it.
+      double total = 0.0;
+      for (size_t k = i; k <= j; ++k) {
+        total += sweeps[k];
+      }
+      const double in_angle = pin_in ? *start_angle : std::atan2(
+        first.getY() - cursor.getY(), first.getX() - cursor.getX());
+      const double out_angle = pin_out ? *end_angle : std::atan2(
+        after.getY() - last_corner.getY(), after.getX() - last_corner.getX());
+      const double net = util::sweepBetween(in_angle, out_angle);
+
+      const bool tail = (j + 2 == n) && sweeps[n - 1] < kMinSweep;
+      const double back_room = pin_in ? 0.0 : cursor.distance(first);
+      const double fwd_room = pin_out ? 0.0 :
+        (tail ? 1.0 : kLegShare) * last_corner.distance(after);
+      const double room = pin_in ? fwd_room : (pin_out ? back_room :
+        std::min(back_room, fwd_room));
+
+      // Turning back on itself over a short hop is a u-turn, not a corner: an
+      // arc has no tangent length at 180 degrees, so it must swing past the
+      // vertices into the headland. Over a long hop the reversal is a detour.
+      const double hop = first.distance(last_corner);
+      const bool uturn = net > kReversalSweep && hop < kUturnHopWidths * op_width;
+
+      // Offset of the outgoing leg from the line the robot arrives on. Measured
+      // off the entry heading, which the approach segment cannot give when the
+      // maneuver starts at the swath.
+      const double sep = std::fabs(
+        std::cos(in_angle) * (after.getY() - first.getY()) -
+        std::sin(in_angle) * (after.getX() - first.getX()));
+
+      // Legs closer than a turning diameter cannot be joined by a half circle,
+      // so the maneuver has to loop. That is the connection's geometry.
+      if (uturn) {
+        const double need = 2.0 * turnRadius(robot, net, continuous);
+        if (sep < need) {
+          RCLCPP_DEBUG(
+            logger,
+            "corner %zu span=%zu v=(%.2f,%.2f) u-turn legs %.2fm apart, %.2fm needed to "
+            "come round: the turn has to loop",
+            i, span, first.getX(), first.getY(), sep, need);
+        }
+      }
+
+      // One line per attempt, so a corner that stays sharp can be read against
+      // its neighbours.
+      const auto report =
+        [&](const char * outcome, double back_off, double value, double limit) {
+          RCLCPP_DEBUG(
+            logger,
+            "corner %zu span=%zu prev=(%.2f,%.2f) v=(%.2f,%.2f)..(%.2f,%.2f) next=(%.2f,%.2f) "
+            "legs=%.2f/%.2f net=%.0f total=%.0f uturn=%d back=%.3f %s %.3f/%.3f",
+            i, span, cursor.getX(), cursor.getY(), first.getX(), first.getY(),
+            last_corner.getX(), last_corner.getY(), after.getX(), after.getY(),
+            cursor.distance(first), last_corner.distance(after),
+            net * 180.0 / M_PI, total * 180.0 / M_PI, uturn ? 1 : 0,
+            back_off, outcome, value, limit);
+        };
+
+      // An arc of radius R meets the legs R*tan(net/2) from the vertex and cuts
+      // back_off*tan(net/4) inside it, which bounds the offset at both ends.
+      double lo = kMinBackoffRadii * turnRadius(robot, net, continuous);
+      double hi = room;
+      if (!uturn) {
+        if (net > M_PI - 1e-3) {
+          report("reversal-too-wide", 0.0, hop, kUturnHopWidths * op_width);
+          continue;
+        }
+        lo = std::max(
+          kRadiusMargin * turnRadius(robot, net, continuous) * std::tan(0.5 * net), lo);
+        hi = std::min(hi, cut_tol / std::max(std::tan(0.25 * net), 1e-6));
+      }
+      // On a jog the corners cancel, so tan(net/4) and that bound vanish with
+      // them. Bound the offset by the ground the maneuver makes up instead.
+      hi = std::min(hi, sep + kRadiusMargin * (1.0 + total) * radius);
+      if (lo > hi) {
+        report("no-room needs/has", 0.0, lo, hi);
+        continue;
+      }
+
+      // A fillet is symmetric, so it meets both legs the same distance out. A
+      // u-turn only leaves one leg and arrives on the other, so it takes what
+      // each has: room is what turns a cusped teardrop into a drivable turn.
+      double in_reach = hi;
+      double out_reach = hi;
+      if (uturn) {
+        const double reach = kUturnReachRadii * turnRadius(robot, net, continuous);
+        in_reach = std::max(lo, std::min(back_room, reach));
+        out_reach = std::max(lo, std::min(fwd_room, reach));
+      }
+      if (pin_in) {
+        in_reach = 0.0;
+      }
+      if (pin_out) {
+        out_reach = 0.0;
+      }
+
+      // A continuous curvature turn needs more room than those tangent lengths,
+      // by an amount not worth predicting, so widen until the planner answers.
+      // A fillet is tried tightest first, where it cuts least; a u-turn widest.
+      const std::array<double, 3> fracs =
+        uturn ? std::array<double, 3>{1.0, 0.5, 0.0} : std::array<double, 3>{0.0, 0.5, 1.0};
+      for (const double frac : fracs) {
+        const double back_off = pin_in ? 0.0 : lo + frac * (in_reach - lo);
+        const double fwd_off = pin_out ? 0.0 : lo + frac * (out_reach - lo);
+        const Point entry = util::pointAlong(first, cursor, back_off);
+        const Point exit = util::pointAlong(last_corner, after, fwd_off);
+        Path arc = curve.createTurn(robot, entry, in_angle, exit, out_angle);
+        if (arc.size() == 0) {
+          report("planner-returned-nothing", back_off, 0.0, 0.0);
+          continue;
+        }
+
+        // A feasible pair of poses can still come back as a loop, which sits
+        // well inside a corridor several times its radius, so deviation alone
+        // lets it through. Length separates them: a loop costs 2*pi radii more.
+        // A u-turn is allowed the teardrop it needs, anything else is not.
+        double arc_len = 0.0;
+        for (const auto & s : arc.getStates()) {
+          arc_len += s.len;
+        }
+        const double budget = uturn ?
+          entry.distance(exit) + (2.0 * M_PI + total) * radius :
+          entry.distance(exit) + std::max(back_off, radius) * total + kLoopSlackRadii * radius;
+        if (arc_len > budget) {
+          report("over-budget arc/max", back_off, arc_len, budget);
+          continue;
+        }
+
+        std::vector<Point> track{entry};
+        for (size_t k = i; k <= j; ++k) {
+          track.push_back(poly[k]);
+        }
+        track.push_back(exit);
+        const double dev = util::deviationFromTrack(arc, track);
+        if (!uturn && dev > cut_tol) {
+          report("strays dev/max", back_off, dev, cut_tol);
+          continue;
+        }
+
+        report("ROUND arc/max", back_off, arc_len, budget);
+        RCLCPP_DEBUG(
+          logger, "  -> turn %s", util::turnLabel(turns->size()).c_str());
+        addStraight(path, robot, cursor, entry);
+        // Left as the planner returned it, so a Reeds-Shepp leg stays reverse at
+        // turning speed rather than being reported as a pass at cruise.
+        path += arc;
+        turns->push_back(arc);
+        cursor = exit;
+        i = j + 1;
+        rounded = true;
+        break;
+      }
+    }
+
+    if (!rounded) {
+      RCLCPP_DEBUG(
+        logger, "corner %zu (%.2f,%.2f) SHARP", i, poly[i].getX(), poly[i].getY());
+      ++sharp;
+      addStraight(path, robot, cursor, poly[i]);
+      cursor = poly[i];
+      ++i;
+    }
+  }
+  addStraight(path, robot, cursor, poly.back());
+  return sharp;
 }
 
 }  // namespace
@@ -44,6 +317,10 @@ double distanceToSegment(const Point & p, const Point & a, const Point & b)
 Path PathGenerator::generatePath(
   const F2CRoute & route, const opennav_coverage_msgs::msg::PathMode & settings)
 {
+  // The turns held for visualization are this route's, not everything planned
+  // since the server came up.
+  connection_turns_.clear();
+
   PathType action_type = toType(settings.mode);
   PathContinuityType action_continuity_type = toContinuityType(settings.continuity_mode);
   std::shared_ptr<f2c::pp::TurningBase> curve{nullptr};
@@ -64,11 +341,19 @@ Path PathGenerator::generatePath(
     throw CoverageException("No valid path mode set!");
   }
 
-  RCLCPP_DEBUG(
+  RCLCPP_INFO(
     logger_,
     "Generating path with curve: %s", toString(action_type, action_continuity_type).c_str());
   curve->setDiscretization(turn_point_distance);
-  Path path = assemblePath(route, *curve);
+  size_t sharp_corners = 0;
+  Path path = assemblePath(route, *curve, sharp_corners);
+  if (sharp_corners > 0) {
+    RCLCPP_WARN(
+      logger_,
+      "%zu connection corner(s) left sharp: no turn fits within %.2fm of the track. "
+      "Widen operation_width or lower min_turning_radius if the controller cannot hold them.",
+      sharp_corners, kCornerCutTol * robot_params_->getOperationWidth());
+  }
 
   // Optionally thin out near-duplicate points (e.g. in turns)
   if (reduce_path_) {
@@ -77,25 +362,27 @@ Path PathGenerator::generatePath(
   return path;
 }
 
-Path PathGenerator::assemblePath(const F2CRoute & route, f2c::pp::TurningBase & curve)
+Path PathGenerator::assemblePath(
+  const F2CRoute & route, f2c::pp::TurningBase & curve, size_t & sharp_corners)
 {
   auto & robot = robot_params_->getRobot();
   Path path;
+  sharp_corners = 0;
   for (size_t i = 0; i < route.sizeVectorSwaths(); ++i) {
     const Swaths prev = (i > 0) ? route.getSwaths(i - 1) : Swaths();
     const F2CMultiPoint connection =
       (i < route.sizeConnections()) ? route.getConnection(i) : F2CMultiPoint();
-    appendConnection(path, prev, connection, route.getSwaths(i), curve);
+    sharp_corners += appendConnection(path, prev, connection, route.getSwaths(i), curve);
     path += generator_->planPath(robot, route.getSwaths(i), curve);
   }
   if (route.sizeConnections() > route.sizeVectorSwaths()) {
-    appendConnection(
+    sharp_corners += appendConnection(
       path, route.getLastSwaths(), route.getLastConnection(), Swaths(), curve);
   }
   return path;
 }
 
-void PathGenerator::appendConnection(
+size_t PathGenerator::appendConnection(
   Path & path, const Swaths & prev, const F2CMultiPoint & connection,
   const Swaths & next, f2c::pp::TurningBase & curve)
 {
@@ -103,7 +390,7 @@ void PathGenerator::appendConnection(
   const bool has_prev = prev.size() > 0;
   const bool has_next = next.size() > 0;
   if (!has_prev && !has_next && connection.size() < 2) {
-    return;
+    return 0;
   }
 
   std::vector<Point> pts;
@@ -117,7 +404,7 @@ void PathGenerator::appendConnection(
     pts.push_back(next[0].startPoint());
   }
   if (pts.size() < 2) {
-    return;
+    return 0;
   }
 
   // Drop attachment spikes: a bridge point past the endpoint that doubles back.
@@ -142,36 +429,58 @@ void PathGenerator::appendConnection(
   // longer than cutting its diagonal, yet shares no ground with it.
   double max_dev = 0.0;
   for (size_t i = 1; i + 1 < pts.size(); ++i) {
-    max_dev = std::max(max_dev, distanceToSegment(pts[i], pts.front(), pts.back()));
+    max_dev = std::max(max_dev, util::distanceToSegment(pts[i], pts.front(), pts.back()));
   }
 
-  // Straight hop: the ordinary headland u-turn, leave it to the curve planner.
-  // A real bend means the graph routed around something worth keeping.
-  if (has_prev && has_next && max_dev < 0.5 * robot_params_->getOperationWidth()) {
-    path += curve.createTurn(
+  // The headland u-turn between neighbouring swaths, where the track is the
+  // straight hop and there is nothing to follow. A track that runs out to the
+  // cell edge instead strays by half an operation width, the offset the
+  // outermost swath keeps from it, so the tolerance has to stay well under that
+  // figure or those connections shortcut the headland.
+  const double op_width = robot_params_->getOperationWidth();
+  bool direct = has_prev && has_next && max_dev < kDirectHopDev * op_width;
+
+  // Neighbouring swaths that double back on each other connect through a u-turn,
+  // which is not a corner to round: an arc through a 180 degree vertex has no
+  // tangent length, so the maneuver has to swing past the vertex into the
+  // headland rather than stay inside the track. The hop guards it - a long
+  // connection that happens to reverse is a detour to follow, not a corner.
+  if (has_prev && has_next && !direct) {
+    const double delta = prev.back().getOutAngle() - next[0].getInAngle();
+    const double reversal = std::fabs(std::atan2(std::sin(delta), std::cos(delta)));
+    const double hop = prev.back().endPoint().distance(next[0].startPoint());
+    direct = reversal > kReversalSweep && hop < kUturnHopWidths * op_width;
+  }
+
+  if (direct) {
+    Path turn = curve.createTurn(
       robot, prev.back().endPoint(), prev.back().getOutAngle(),
       next[0].startPoint(), next[0].getInAngle());
-    return;
+    RCLCPP_DEBUG(
+      logger_, "direct hop (%.2f,%.2f)->(%.2f,%.2f) max_dev=%.2f -> turn %s",
+      prev.back().endPoint().getX(), prev.back().endPoint().getY(),
+      next[0].startPoint().getX(), next[0].startPoint().getY(), max_dev,
+      util::turnLabel(connection_turns_.size()).c_str());
+    path += turn;
+    connection_turns_.push_back(turn);
+    return 0;
   }
 
-  // The polyline detours (e.g. around a concave notch): follow it verbatim as
-  // HL_SWATH states so the vehicle stays on the planned border/corridor track.
-  for (size_t i = 0; i + 1 < pts.size(); ++i) {
-    const double dx = pts[i + 1].getX() - pts[i].getX();
-    const double dy = pts[i + 1].getY() - pts[i].getY();
-    const double len = std::hypot(dx, dy);
-    if (len < 1e-6) {
-      continue;
-    }
-    PathState s;
-    s.point = pts[i];
-    s.angle = std::atan2(dy, dx);
-    s.len = len;
-    s.dir = f2c::types::PathDirection::FORWARD;
-    s.type = f2c::types::PathSectionType::HL_SWATH;
-    s.velocity = robot.getCruiseVel();
-    path.addState(s);
+  // Round the corners of the detour (e.g. around a concave notch) but otherwise
+  // follow it, so the vehicle stays on the planned border/corridor track.
+  const std::vector<Point> poly = util::simplifyPolyline(pts, kSimplifyTol * op_width);
+  if (poly.size() < 2) {
+    return 0;
   }
+
+  const bool continuous = active_continuity_type_ == PathContinuityType::CONTINUOUS;
+  const std::optional<double> start_angle = has_prev ?
+    std::optional<double>(prev.back().getOutAngle()) : std::nullopt;
+  const std::optional<double> end_angle = has_next ?
+    std::optional<double>(next[0].getInAngle()) : std::nullopt;
+  return appendRoundedTrack(
+    path, poly, robot, curve, op_width, continuous, start_angle, end_angle,
+    logger_, &connection_turns_);
 }
 
 void PathGenerator::setPathMode(const std::string & new_mode)

--- a/opennav_coverage/src/visualizer.cpp
+++ b/opennav_coverage/src/visualizer.cpp
@@ -30,13 +30,15 @@ void Visualizer::deactivate()
   planning_field_pub_.reset();
   swaths_pub_.reset();
   headland_swaths_pub_.reset();
+  connection_turns_pub_.reset();
 }
 
 void Visualizer::visualize(
   const Field & total_field, const Field & no_headland_field,
   const Point & ref_pt, const nav_msgs::msg::Path & nav_path,
   const Swaths swaths, const std_msgs::msg::Header & header,
-  const Path & headland_path)
+  const Path & headland_path,
+  const std::vector<Path> & connection_turns)
 {
   // F2C strips out reference point of all data, so we need to readd it
   // so that our visualizations mirror the true transformed output
@@ -130,6 +132,69 @@ void Visualizer::visualize(
     }
 
     headland_swaths_pub_->publish(std::move(output_hl));
+  }
+
+  // The turns planned between swath groups, drawn on their own so a rounded
+  // corner can be told apart from one left square. Each carries the label the
+  // planner logs for it.
+  if (connection_turns_pub_->get_subscription_count() > 0) {
+    auto msg = std::make_unique<visualization_msgs::msg::MarkerArray>();
+
+    visualization_msgs::msg::Marker clear;
+    clear.header.stamp = header.stamp;
+    clear.header.frame_id = GLOBAL_FRAME;
+    clear.action = visualization_msgs::msg::Marker::DELETEALL;
+    msg->markers.push_back(clear);
+
+    if (!connection_turns.empty()) {
+      visualization_msgs::msg::Marker lines;
+      lines.header.stamp = header.stamp;
+      lines.header.frame_id = GLOBAL_FRAME;
+      lines.ns = "turns";
+      lines.action = visualization_msgs::msg::Marker::ADD;
+      // LINE_LIST, not LINE_STRIP: the turns are disjoint and a strip would
+      // draw a line across the field between each pair of them.
+      lines.type = visualization_msgs::msg::Marker::LINE_LIST;
+      lines.pose.orientation.w = 1.0;
+      lines.scale.x = 0.05;
+      lines.color.r = 0.7;
+      lines.color.b = 1.0;
+      lines.color.a = 1.0;
+
+      for (size_t t = 0; t != connection_turns.size(); t++) {
+        const auto & turn = connection_turns[t];
+        if (turn.size() == 0) {
+          continue;
+        }
+        for (size_t i = 0; i + 1 < turn.size(); i++) {
+          lines.points.push_back(util::pointToPoint32(util::toMsg(turn[i].point + ref_pt)));
+          lines.points.push_back(util::pointToPoint32(util::toMsg(turn[i + 1].point + ref_pt)));
+        }
+        lines.points.push_back(util::pointToPoint32(util::toMsg(turn.back().point + ref_pt)));
+        lines.points.push_back(util::pointToPoint32(util::toMsg(turn.back().atEnd() + ref_pt)));
+
+        visualization_msgs::msg::Marker label;
+        label.header.stamp = header.stamp;
+        label.header.frame_id = GLOBAL_FRAME;
+        label.ns = "turn_labels";
+        label.id = static_cast<int>(t);
+        label.action = visualization_msgs::msg::Marker::ADD;
+        label.type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
+        label.pose.orientation.w = 1.0;
+        label.pose.position =
+          util::pointToPoint32(util::toMsg(turn[turn.size() / 2].point + ref_pt));
+        label.scale.z = 0.4;
+        label.color.r = 1.0;
+        label.color.g = 1.0;
+        label.color.b = 1.0;
+        label.color.a = 1.0;
+        label.text = util::turnLabel(t);
+        msg->markers.push_back(label);
+      }
+      msg->markers.push_back(lines);
+    }
+
+    connection_turns_pub_->publish(std::move(msg));
   }
 }
 

--- a/opennav_coverage/test/test_path.cpp
+++ b/opennav_coverage/test/test_path.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 #include "gtest/gtest.h"
 #include "rclcpp/rclcpp.hpp"
 #include "opennav_coverage/robot_params.hpp"
@@ -193,6 +197,200 @@ TEST(PathTests, TestpathGenerationMultiCellConnections)
   auto path = generator.generatePath(route, path_settings);
   EXPECT_GT(path.size(), 0u);
   EXPECT_TRUE(std::isfinite(path.getTaskTime()));
+}
+
+namespace
+{
+
+// Distance from `q` to the polyline through the path's states. Straight runs are
+// a single state, so measuring to the states alone would miss the track between.
+double distanceToPath(const Path & path, const F2CPoint & q)
+{
+  double best = std::numeric_limits<double>::max();
+  for (size_t i = 1; i < path.size(); ++i) {
+    const auto & a = path[i - 1].point;
+    const auto & b = path[i].point;
+    const double dx = b.getX() - a.getX();
+    const double dy = b.getY() - a.getY();
+    const double len2 = dx * dx + dy * dy;
+    double t = 0.0;
+    if (len2 > 1e-12) {
+      t = std::clamp(
+        ((q.getX() - a.getX()) * dx + (q.getY() - a.getY()) * dy) / len2, 0.0, 1.0);
+    }
+    best = std::min(
+      best, std::hypot(q.getX() - (a.getX() + t * dx), q.getY() - (a.getY() + t * dy)));
+  }
+  return best;
+}
+
+double maxHeadingStep(const Path & path)
+{
+  double worst = 0.0;
+  for (size_t i = 1; i < path.size(); ++i) {
+    const double delta = path[i].angle - path[i - 1].angle;
+    worst = std::max(worst, std::fabs(std::atan2(std::sin(delta), std::cos(delta))));
+  }
+  return worst;
+}
+
+// Two opposing swaths with a gap between them, for connections to span.
+void makeSwaths(double x_second, F2CSwaths & first, F2CSwaths & second)
+{
+  first.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+  second.emplace_back(
+    F2CSwath(F2CLineString({F2CPoint(x_second, 20), F2CPoint(x_second, 0)})));
+}
+
+}  // namespace
+
+TEST(PathTests, TestConnectionCornersAreSmoothed)
+{
+  // Corners of a detouring connection must go through the turn planner: a raw
+  // boundary vertex is a heading step no turning radius can hold.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  PathShim generator(node, &robot_params);
+
+  F2CSwaths first, second;
+  makeSwaths(30.0, first, second);
+
+  // Connection detours over the top with two right-angle corners.
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+    F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(30, 40), F2CPoint(30, 20)}),
+    second);
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  ASSERT_GT(path.size(), 2u);
+
+  EXPECT_LT(maxHeadingStep(path), 1.0);  // a square corner would leave a ~1.57 rad step
+
+  // Smoothing must round the corners, not skip the detour: a path that cut
+  // straight across would satisfy the heading bound above on its own.
+  EXPECT_LT(distanceToPath(path, F2CPoint(15, 40)), 0.5);
+  EXPECT_LT(distanceToPath(path, F2CPoint(0, 30)), 0.5);
+  EXPECT_LT(distanceToPath(path, F2CPoint(30, 30)), 0.5);
+}
+
+TEST(PathTests, TestConnectionJogIsSmoothed)
+{
+  // A jog with two corners a couple of metres apart: too tight to take one at a
+  // time, so it has to be rounded as a single S rather than driven square.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  PathShim generator(node, &robot_params);
+
+  F2CSwaths first, second;
+  makeSwaths(30.0, first, second);
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+    F2CMultiPoint({
+      F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(14, 40), F2CPoint(16, 42),
+      F2CPoint(30, 42), F2CPoint(30, 20)}),
+    second);
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  ASSERT_GT(path.size(), 2u);
+
+  EXPECT_LT(maxHeadingStep(path), 1.0);
+  EXPECT_LT(distanceToPath(path, F2CPoint(25, 42)), 0.5);
+}
+
+TEST(PathTests, TestNeighbourUturnIsPlannedAsATurn)
+{
+  // Neighbouring swaths doubling back on each other. The track wanders out past
+  // the straight-hop tolerance, but this is still a u-turn, and a u-turn is not
+  // a corner to round: driving its two vertices square would put a pair of right
+  // angles where the headland maneuver belongs.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  PathShim generator(node, &robot_params);
+
+  F2CSwaths first, second;
+  first.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+  second.emplace_back(F2CSwath(F2CLineString({F2CPoint(2.5, 20), F2CPoint(2.5, 0)})));
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+    F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 21.5), F2CPoint(2.5, 21.5), F2CPoint(2.5, 20)}),
+    second);
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  ASSERT_GT(path.size(), 2u);
+
+  // Squaring off the two vertices would leave ~1.57 rad steps at each.
+  EXPECT_LT(maxHeadingStep(path), 1.0);
+}
+
+TEST(PathTests, TestCurvedConnectionIsNotFlattened)
+{
+  // Every point of this arc sits millimetres from the chord of its immediate
+  // neighbours, so simplifying by local collinearity would drop them one by one
+  // and collapse a 5m bulge onto its chord. The kept track must stay on the arc.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  PathShim generator(node, &robot_params);
+
+  F2CSwaths first, second;
+  makeSwaths(40.0, first, second);
+
+  F2CMultiPoint arc;
+  for (int k = 0; k <= 40; ++k) {
+    const double x = static_cast<double>(k);
+    arc.addPoint(F2CPoint(x, 20.0 + 5.0 * std::sin(M_PI * x / 40.0)));
+  }
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(arc, second);
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  ASSERT_GT(path.size(), 2u);
+
+  EXPECT_LT(distanceToPath(path, F2CPoint(20, 25)), 0.5);   // apex
+  EXPECT_LT(distanceToPath(path, F2CPoint(10, 23.54)), 0.5);
+  EXPECT_LT(distanceToPath(path, F2CPoint(30, 23.54)), 0.5);
+}
+
+TEST(PathTests, TestUnroundableCornerKeepsTheTrack)
+{
+  // With a turning circle far wider than the corridor, no maneuver fits through
+  // the corner. The corner then stays sharp on purpose: cutting it would put the
+  // vehicle off the planned track, which is worse than a step the controller
+  // has to absorb.
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+    {rclcpp::Parameter("min_turning_radius", 8.0),
+      rclcpp::Parameter("operation_width", 2.5)});
+  auto node = std::make_shared<rclcpp::Node>("test_node", options);
+  RobotParams robot_params(node);
+  PathShim generator(node, &robot_params);
+
+  F2CSwaths first, second;
+  makeSwaths(30.0, first, second);
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+    F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(30, 40), F2CPoint(30, 20)}),
+    second);
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  ASSERT_GT(path.size(), 2u);
+
+  // Corners themselves, not just their neighbourhood: nothing may be cut here.
+  EXPECT_LT(distanceToPath(path, F2CPoint(0, 40)), 0.1);
+  EXPECT_LT(distanceToPath(path, F2CPoint(30, 40)), 0.1);
 }
 
 }  // namespace opennav_coverage

--- a/opennav_coverage/test/test_path.cpp
+++ b/opennav_coverage/test/test_path.cpp
@@ -393,4 +393,143 @@ TEST(PathTests, TestUnroundableCornerKeepsTheTrack)
   EXPECT_LT(distanceToPath(path, F2CPoint(30, 40)), 0.1);
 }
 
+TEST(PathTests, TestSwathHeadingRoundsTheJunction)
+{
+  // The junction with a swath is a corner: the connection need not leave along
+  // the heading the swath holds. Without that heading it is not seen as one.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  PathShim generator(node, &robot_params);
+
+  // Swath runs east and ends where the connection sets off north.
+  F2CSwaths first, second;
+  first.emplace_back(F2CSwath(F2CLineString({F2CPoint(-20, 20), F2CPoint(0, 20)})));
+  second.emplace_back(F2CSwath(F2CLineString({F2CPoint(30, 20), F2CPoint(30, 0)})));
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+    F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(30, 40), F2CPoint(30, 20)}),
+    second);
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  ASSERT_GT(path.size(), 2u);
+
+  EXPECT_LT(maxHeadingStep(path), 1.0);  // driven straight off, a ~1.57 rad step
+
+  // Starts on the swath's own end pose, not up the leg at the next vertex.
+  const auto & turns = generator.getConnectionTurns();
+  ASSERT_FALSE(turns.empty());
+  EXPECT_NEAR(turns.front()[0].point.getX(), 0.0, 1e-3);
+  EXPECT_NEAR(turns.front()[0].point.getY(), 20.0, 1e-3);
+}
+
+TEST(PathTests, TestOpenEndedConnectionFollowsTheTrack)
+{
+  // Route-end connections have a swath on one side only. The open end holds no
+  // heading, so it is no corner, and nothing may be read off it.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  PathShim generator(node, &robot_params);
+
+  F2CSwaths swaths;
+  swaths.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+
+  // A lead-in from off the field, and a lead-out back off it.
+  F2CRoute route;
+  route.addConnectedSwaths(
+    F2CMultiPoint({F2CPoint(-20, -20), F2CPoint(0, -20), F2CPoint(0, 0)}), swaths);
+  route.addConnection(
+    F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(-20, 40)}));
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  ASSERT_GT(path.size(), 2u);
+
+  EXPECT_LT(maxHeadingStep(path), 1.0);
+
+  // One corner each; the open ends are driven through.
+  EXPECT_EQ(generator.getConnectionTurns().size(), 2u);
+
+  EXPECT_LT(distanceToPath(path, F2CPoint(-10, -20)), 0.5);
+  EXPECT_LT(distanceToPath(path, F2CPoint(0, 30)), 0.5);
+}
+
+TEST(PathTests, TestShallowCornerKeepsAnApproach)
+{
+  // A shallow corner's fillet tangent collapses with it. The floor under that
+  // is what leaves the planner a maneuver rather than two poses 6cm apart.
+  auto node = std::make_shared<rclcpp::Node>("test_node");
+  RobotParams robot_params(node);
+  PathShim generator(node, &robot_params);
+
+  F2CSwaths swaths;
+  swaths.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+
+  // Lead-out bending 15deg at (0, 50), well over the ~3deg driven straight.
+  const double bend = 15.0 * M_PI / 180.0;
+  const F2CPoint corner(0, 50);
+  const F2CPoint tip(30.0 * std::sin(bend), 50.0 + 30.0 * std::cos(bend));
+
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), swaths);
+  route.addConnection(F2CMultiPoint({F2CPoint(0, 20), corner, tip}));
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  ASSERT_GT(path.size(), 2u);
+
+  // Rounded rather than left sharp, and the only corner on the route.
+  const auto & turns = generator.getConnectionTurns();
+  ASSERT_EQ(turns.size(), 1u);
+
+  // 6cm of tangent here, nothing to turn in: it must start further back.
+  EXPECT_GT(turns.front()[0].point.distance(corner), 0.15);
+
+  EXPECT_LT(distanceToPath(path, F2CPoint(0, 35)), 0.5);  // leg in followed
+  // The leg out is one state with no point at its end, so check its heading.
+  EXPECT_NEAR(path[path.size() - 1].angle, M_PI / 2.0 - bend, 1e-3);
+}
+
+TEST(PathTests, TestTightCornersAreFoldedIntoOneTurn)
+{
+  // Corners too close to round one at a time: rounding the first leaves the
+  // second no approach, so the pair has to be taken as one S.
+  //
+  // The radius sets how close is too close. At the default 0.4m the jog would
+  // be small enough to pass as a straight hop and never reach the rounding.
+  rclcpp::NodeOptions options;
+  options.parameter_overrides(
+    {rclcpp::Parameter("min_turning_radius", 2.0),
+      rclcpp::Parameter("operation_width", 2.5)});
+  auto node = std::make_shared<rclcpp::Node>("test_node", options);
+  RobotParams robot_params(node);
+  PathShim generator(node, &robot_params);
+
+  F2CSwaths first, second;
+  first.emplace_back(F2CSwath(F2CLineString({F2CPoint(0, 0), F2CPoint(0, 20)})));
+  second.emplace_back(F2CSwath(F2CLineString({F2CPoint(3, 63), F2CPoint(3, 83)})));
+
+  // Corners at (0,40) and (3,43): 4.24m apart, inside the 4.8m a turn needs.
+  F2CRoute route;
+  route.addConnectedSwaths(F2CMultiPoint(), first);
+  route.addConnectedSwaths(
+    F2CMultiPoint({F2CPoint(0, 20), F2CPoint(0, 40), F2CPoint(3, 43), F2CPoint(3, 63)}),
+    second);
+
+  opennav_coverage_msgs::msg::PathMode path_settings;
+  auto path = generator.generatePath(route, path_settings);
+  ASSERT_GT(path.size(), 2u);
+
+  // Taken one at a time they would each round here, and leave two.
+  EXPECT_EQ(generator.getConnectionTurns().size(), 1u);
+
+  // Their deflections cancel, so nothing bounds the fold by the corner it cuts.
+  // It still has to make the jog: this is the midpoint of the leg between them.
+  EXPECT_LT(distanceToPath(path, F2CPoint(1.5, 41.5)), 0.5);
+
+  EXPECT_LT(maxHeadingStep(path), 0.2);  // square corners leave ~0.79 rad
+}
+
 }  // namespace opennav_coverage

--- a/opennav_row_coverage/src/row_coverage_server.cpp
+++ b/opennav_row_coverage/src/row_coverage_server.cpp
@@ -267,6 +267,8 @@ RowCoverageServer::dynamicParametersCallback(std::vector<rclcpp::Parameter> para
     if (type == ParameterType::PARAMETER_DOUBLE) {
       if (name == "default_turn_point_distance") {
         path_gen_->setTurnPointDistance(parameter.as_double());
+      } else if (name == "corner_cut_tolerance") {
+        path_gen_->setCornerCutTolerance(parameter.as_double());
       } else if (name == "robot_width") {
         auto & robot = robot_params_->getRobot();
         robot.setWidth(parameter.as_double());


### PR DESCRIPTION
### Problem

A connection between two swath groups was always driven as a single turn from the end of one group to the start of the next, ignoring the connection's own waypoints.

That is right for the u-turn between neighbouring swaths, where the track *is* the straight hop. It is wrong everywhere else. On a detour around a concave notch, or between decomposed cells, the route deliberately walks the border to stay inside the field, and planning a turn straight across it cuts through exactly the ground the route was avoiding.

### Approach

Follow the connection's own track, rounding its corners through the turn planner and leaving a corner square when no maneuver fits within half an operation width of it.

Which of the two treatments a connection gets is decided by **how far its track strays from the straight hop**, not by the ratio of their lengths. A long cell's rounded corner is only about 20% longer than the diagonal across it, yet shares no ground with it, so a length ratio cannot tell them apart.

The corners at either end are planned from the **headings of the swaths there**, not from the track's first and last legs. The border graph splices the swath endpoint into the ring, so those legs are often a short spur that the robot is not driving along. Reading the heading off them plans the turn from a pose the robot is never in: a 90° corner comes out as an S, a reversal as an L, and the arc meets the swath at a cusp. Corners too close together to be taken one at a time are folded into a single maneuver for the same reason.

### Known limitations

Two things I deliberately left out of this PR rather than hide:

1. **`kCornerCutTol` is a compile-time constant** (`0.5 × operation_width`). It is really a user-facing tolerance — how far a rounded corner may leave the track — and belongs as a ROS parameter beside `operation_width` and `min_turning_radius`. Kept as a constant here to hold the PR to one concern; happy to add the parameter here instead if you would rather it landed together.
2. **The end-heading logic and the shallow-corner bound are not unit tested.** The five tests above cover the rounding; the heading-aware ends, the corner folding and the jog bound were verified in RViz only.

The turn maths is heuristic and carries a number of tuning constants — the block at the top of `path_generator.cpp`. They are all fractions of the operation width or multiples of the turning radius, never absolute distances, but they are tuned rather than derived and are the part most worth a second opinion.
